### PR TITLE
Phase D: Data integrity — stable IDs, unique URLs, utility consolidation

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -318,22 +318,22 @@ These are deferred from Phase 1 migration intentionally. They are non-urgent but
 
 **Goal:** Centralize the two patterns that have the most duplicated state management logic.
 
-| #          | Task                                                   | Files to modify                                                                                                      | Verify                                        |
-| ---------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| ~~C-1~~ ✅ | `useConfirmDelete<T>()` hook + `<DeleteConfirmDialog>` | New `lib/useConfirmDelete.ts`, 5 dialog components                                                                   | Delete flows work in all affected dialogs     |
-| ~~C-2~~ ✅ | `<FullscreenDialog>` layout wrapper                    | New `ui/fullscreen-dialog.tsx`; all 4 fullscreen dialogs (ManageCharacters included)                                 | Fullscreen dialogs still open/close correctly |
+| #          | Task                                                   | Files to modify                                                                      | Verify                                        |
+| ---------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------ | --------------------------------------------- |
+| ~~C-1~~ ✅ | `useConfirmDelete<T>()` hook + `<DeleteConfirmDialog>` | New `lib/useConfirmDelete.ts`, 5 dialog components                                   | Delete flows work in all affected dialogs     |
+| ~~C-2~~ ✅ | `<FullscreenDialog>` layout wrapper                    | New `ui/fullscreen-dialog.tsx`; all 4 fullscreen dialogs (ManageCharacters included) | Fullscreen dialogs still open/close correctly |
 
 ---
 
-### Phase D — Data integrity improvements
+### ~~Phase D — Data integrity improvements~~ ✅
 
 **Goal:** Fix the one correctness issue and the ID type inconsistency before they cause real problems.
 
-| #   | Task                                                                                        | Files to modify                                                                                     | Verify                                                           |
-| --- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| D-1 | Enforce unique URLs in `imageStore.addImage`; use stable image ID as key in `imageGrid.tsx` | `imageStore.ts`, `imageGrid.tsx`                                                                    | Adding duplicate URL is prevented (or deduplicated gracefully)   |
-| D-2 | Migrate `Character.id` from `number` to `string` (UUID)                                     | `characterStore.ts` (bump to v1, add migration), `manageCharactersDialog.tsx`, `migrations.test.ts` | All existing character data survives; add/edit/delete still work |
-| D-3 | Move `fmtBonus` to `lib/utils.ts`                                                           | `open5eSearchDialog.tsx`, `utils.ts`                                                                | Open5e search still maps bonus values correctly                  |
+| #          | Task                                                                                        | Files to modify                                                                                     | Verify                                                           |
+| ---------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| ~~D-1~~ ✅ | Enforce unique URLs in `imageStore.addImage`; use stable image ID as key in `imageGrid.tsx` | `imageStore.ts`, `imageGrid.tsx`, `add-image-dialog.tsx`                                            | Adding duplicate URL shows inline error; images have stable IDs  |
+| ~~D-2~~ ✅ | Migrate `Character.id` from `number` to `string` (UUID)                                     | `characterStore.ts` (bump to v1, add migration), `manageCharactersDialog.tsx`, `migrations.test.ts` | All existing character data survives; add/edit/delete still work |
+| ~~D-3~~ ✅ | Move `fmtBonus` to `lib/utils.ts` as `formatBonus`                                          | `open5eSearchDialog.tsx`, `utils.ts`                                                                | Open5e search still maps bonus values correctly                  |
 
 ---
 

--- a/src/components/characters/manageCharactersDialog.tsx
+++ b/src/components/characters/manageCharactersDialog.tsx
@@ -20,7 +20,7 @@ interface ManageCharactersDialogProps {
   onClose: () => void;
 }
 
-type EditingCell = { id: number; field: keyof Character } | null;
+type EditingCell = { id: string; field: keyof Character } | null;
 
 export default function ManageCharactersDialog({ isOpen, onClose }: ManageCharactersDialogProps) {
   const { characters, addCharacter, editCharacter, deleteCharacter } = useCharacterStore();
@@ -42,7 +42,7 @@ export default function ManageCharactersDialog({ isOpen, onClose }: ManageCharac
     setEditing(null);
   };
 
-  const isEditing = (id: number, field: keyof Character) =>
+  const isEditing = (id: string, field: keyof Character) =>
     editing?.id === id && editing?.field === field;
 
   const EditableCell = ({

--- a/src/components/encounters/open5eSearchDialog.tsx
+++ b/src/components/encounters/open5eSearchDialog.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
 import { StatBlock } from '../../store/encounterStore';
+import { formatBonus } from '@/lib/utils';
 
 interface Open5eCreature {
   key: string;
@@ -66,10 +67,6 @@ const SAVE_ABBREVS: Record<string, string> = {
   charisma: 'CHA'
 };
 
-function fmtBonus(n: number): string {
-  return n >= 0 ? `+${n}` : `${n}`;
-}
-
 function buildSpeed(s: Open5eCreature['speed_all']): string | undefined {
   const u = s.unit === 'feet' ? 'ft.' : s.unit;
   const parts: string[] = [];
@@ -83,7 +80,7 @@ function buildSpeed(s: Open5eCreature['speed_all']): string | undefined {
 
 function buildSaves(saves: Record<string, number>): string | undefined {
   const parts = Object.entries(saves).map(
-    ([k, v]) => `${SAVE_ABBREVS[k] ?? k.toUpperCase()} ${fmtBonus(v)}`
+    ([k, v]) => `${SAVE_ABBREVS[k] ?? k.toUpperCase()} ${formatBonus(v)}`
   );
   return parts.length ? parts.join(', ') : undefined;
 }
@@ -94,7 +91,7 @@ function buildSkills(skills: Record<string, number>): string | undefined {
       .split('_')
       .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
       .join(' ');
-  const parts = Object.entries(skills).map(([k, v]) => `${capitalize(k)} ${fmtBonus(v)}`);
+  const parts = Object.entries(skills).map(([k, v]) => `${capitalize(k)} ${formatBonus(v)}`);
   return parts.length ? parts.join(', ') : undefined;
 }
 
@@ -138,7 +135,7 @@ function toStatBlock(m: Open5eCreature): Omit<StatBlock, 'id'> {
     name: m.name,
     size: m.size.name || undefined,
     creatureType: m.type.name || undefined,
-    proficiencyBonus: m.proficiency_bonus != null ? fmtBonus(m.proficiency_bonus) : undefined,
+    proficiencyBonus: m.proficiency_bonus != null ? formatBonus(m.proficiency_bonus) : undefined,
     ac: m.armor_class,
     acDesc: m.armor_detail || undefined,
     hp: m.hit_points,

--- a/src/components/images/add-image-dialog.tsx
+++ b/src/components/images/add-image-dialog.tsx
@@ -7,7 +7,7 @@ interface AddImageDialogProps {
   open: boolean;
   onClose: () => void;
   targetFolder: string;
-  onSave: (url: string, title: string) => void;
+  onSave: (url: string, title: string) => boolean;
 }
 
 export default function AddImageDialog({
@@ -18,17 +18,29 @@ export default function AddImageDialog({
 }: AddImageDialogProps) {
   const [url, setUrl] = useState('');
   const [imageTitle, setImageTitle] = useState('');
+  const [dupeError, setDupeError] = useState(false);
+
+  const handleClose = () => {
+    setUrl('');
+    setImageTitle('');
+    setDupeError(false);
+    onClose();
+  };
 
   const handleSave = () => {
     if (!url.trim()) return;
-    onSave(url.trim(), imageTitle.trim());
-    onClose();
+    const added = onSave(url.trim(), imageTitle.trim());
+    if (!added) {
+      setDupeError(true);
+      return;
+    }
+    handleClose();
   };
 
   return (
     <SimpleDialog
       open={open}
-      onClose={onClose}
+      onClose={handleClose}
       title='Add Image'
       description={`Save an image URL to "${targetFolder}".`}
       onSubmit={handleSave}
@@ -49,10 +61,19 @@ export default function AddImageDialog({
             id='add-img-url'
             autoFocus
             value={url}
-            onChange={(e: ChangeEvent<HTMLInputElement>) => setUrl(e.target.value)}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setUrl(e.target.value);
+              setDupeError(false);
+            }}
             placeholder='https://…'
             onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+            aria-describedby={dupeError ? 'add-img-dupe-error' : undefined}
           />
+          {dupeError && (
+            <p id='add-img-dupe-error' className='text-xs text-destructive'>
+              This URL already exists in &quot;{targetFolder}&quot;.
+            </p>
+          )}
         </div>
       </div>
     </SimpleDialog>

--- a/src/components/images/imageGrid.tsx
+++ b/src/components/images/imageGrid.tsx
@@ -13,7 +13,7 @@ export default function ImageGrid({ images, onSendImage }: ImageGridProps) {
     <div className='grid grid-cols-4 gap-2'>
       {images.map((image) => (
         <ImageThumbnail
-          key={image.url}
+          key={image.id}
           image={image}
           action={
             <Button

--- a/src/components/images/manageImagesDialog.tsx
+++ b/src/components/images/manageImagesDialog.tsx
@@ -33,6 +33,7 @@ export default function ManageImagesDialog({ isOpen, onClose }: ManageImagesDial
 
   const [targetFolder, setTargetFolder] = useState('');
   const [subDialog, setSubDialog] = useState<SubDialog>(null);
+  const [openFolders, setOpenFolders] = useState<string[]>([]);
   const deleteImage = useConfirmDelete<{ folder: string; image: Image }>();
   const deleteFolder = useConfirmDelete<string>();
 
@@ -94,7 +95,11 @@ export default function ManageImagesDialog({ isOpen, onClose }: ManageImagesDial
           {folders.length === 0 ? (
             <p className='text-sm text-muted-foreground'>No folders yet.</p>
           ) : (
-            <Accordion type='multiple' className='space-y-1'>
+            <Accordion
+              type='multiple'
+              value={openFolders}
+              onValueChange={setOpenFolders}
+              className='space-y-1'>
               {folders.map((folder) => (
                 <AccordionItem
                   key={folder.folderName}
@@ -131,7 +136,7 @@ export default function ManageImagesDialog({ isOpen, onClose }: ManageImagesDial
                       <div className='grid grid-cols-4 gap-2'>
                         {folder.images.map((image) => (
                           <ImageThumbnail
-                            key={image.url}
+                            key={image.id}
                             image={image}
                             imgClassName='w-full h-20 object-cover'
                             action={

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -67,7 +67,7 @@ function AccordionContent({
       {...props}>
       <div
         className={cn(
-          'h-(--radix-accordion-content-height) pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4',
+          'pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4',
           className
         )}>
         {children}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,7 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatBonus(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}

--- a/src/store/__tests__/migrations.test.ts
+++ b/src/store/__tests__/migrations.test.ts
@@ -118,9 +118,33 @@ describe('combatStore migrations', () => {
   });
 });
 
+const v1Characters = {
+  characters: [
+    {
+      id: '1',
+      name: 'Bruenor',
+      charClass: 'Fighter',
+      background: 'Soldier',
+      ac: 18,
+      pp: 10,
+      pi: 10,
+      init: 2,
+      sheetUrl: 'https://dndbeyond.com'
+    }
+  ]
+};
+
 describe('characterStore migrations', () => {
-  it('v0 state is preserved', () => {
-    expect(migrateCharacterStore(v0Characters, 0), CONTRACT_BROKEN).toEqual(v0Characters);
+  it('v1 state is preserved', () => {
+    expect(migrateCharacterStore(structuredClone(v1Characters), 1), CONTRACT_BROKEN).toEqual(
+      v1Characters
+    );
+  });
+
+  it('v0 → v1: numeric id converted to string', () => {
+    const result = migrateCharacterStore(structuredClone(v0Characters), 0) as typeof v1Characters;
+    expect(result.characters[0].id, CONTRACT_BROKEN).toBe('1');
+    expect(result.characters[0].name, CONTRACT_BROKEN).toBe('Bruenor');
   });
 });
 

--- a/src/store/__tests__/migrations.test.ts
+++ b/src/store/__tests__/migrations.test.ts
@@ -93,6 +93,21 @@ const v0Images = {
   ]
 };
 
+const v1Images = {
+  folders: [
+    {
+      folderName: 'Goblins',
+      images: [
+        {
+          id: 'a1b2c3d4-0000-0000-0000-000000000001',
+          url: 'https://example.com/goblin.png',
+          title: 'Goblin'
+        }
+      ]
+    }
+  ]
+};
+
 const v0Notes = { notes: 'Session notes here.' };
 
 const v0Combat = { actors: [], selectedIndex: 0, round: 1 };
@@ -110,8 +125,17 @@ describe('characterStore migrations', () => {
 });
 
 describe('imageStore migrations', () => {
-  it('v0 state is preserved', () => {
-    expect(migrateImageStore(v0Images, 0), CONTRACT_BROKEN).toEqual(v0Images);
+  it('v1 state is preserved', () => {
+    expect(migrateImageStore(structuredClone(v1Images), 1), CONTRACT_BROKEN).toEqual(v1Images);
+  });
+
+  it('v0 → v1: images get a stable id', () => {
+    const result = migrateImageStore(structuredClone(v0Images), 0) as typeof v1Images;
+    const image = result.folders[0].images[0];
+    expect(typeof image.id, CONTRACT_BROKEN).toBe('string');
+    expect(image.id.length, CONTRACT_BROKEN).toBeGreaterThan(0);
+    expect(image.url, CONTRACT_BROKEN).toBe('https://example.com/goblin.png');
+    expect(image.title, CONTRACT_BROKEN).toBe('Goblin');
   });
 });
 

--- a/src/store/characterStore.ts
+++ b/src/store/characterStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Character {
-  id: number;
+  id: string;
   name: string;
   charClass: string;
   background: string;
@@ -17,12 +17,12 @@ interface CharacterStore {
   characters: Character[];
   addCharacter: () => void;
   editCharacter: (character: Character) => void;
-  deleteCharacter: (id: number) => void;
+  deleteCharacter: (id: string) => void;
 }
 
 const DEFAULT_CHARACTERS: Character[] = [
   {
-    id: 1,
+    id: crypto.randomUUID(),
     name: 'Bruenor',
     charClass: 'Fighter',
     background: 'Soldier',
@@ -33,7 +33,7 @@ const DEFAULT_CHARACTERS: Character[] = [
     sheetUrl: 'https://dndbeyond.com'
   },
   {
-    id: 2,
+    id: crypto.randomUUID(),
     name: 'Meepo',
     charClass: 'Rogue',
     background: 'Criminal',
@@ -49,9 +49,20 @@ export const STORE_KEY = 'dm-screen/characters';
 
 export function migrateCharacterStore(
   state: unknown,
-  _version: number
+  version: number
 ): { characters: Character[] } {
-  return state as { characters: Character[] };
+  let s = state as { characters: Character[] };
+  if (version < 1) {
+    // Convert numeric ids to strings to align with all other entity types.
+    s = {
+      ...s,
+      characters: s.characters.map((c) => ({
+        ...c,
+        id: String((c as unknown as { id: number }).id)
+      }))
+    };
+  }
+  return s;
 }
 
 export const useCharacterStore = create<CharacterStore>()(
@@ -61,12 +72,11 @@ export const useCharacterStore = create<CharacterStore>()(
 
       addCharacter: () => {
         const { characters } = get();
-        const nextId = characters.length > 0 ? Math.max(...characters.map((c) => c.id)) + 1 : 1;
         set({
           characters: [
             ...characters,
             {
-              id: nextId,
+              id: crypto.randomUUID(),
               name: 'New Character',
               charClass: 'Fighter',
               background: 'Soldier',
@@ -93,7 +103,7 @@ export const useCharacterStore = create<CharacterStore>()(
     }),
     {
       name: STORE_KEY,
-      version: 0,
+      version: 1,
       migrate: migrateCharacterStore
     }
   )

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Image {
+  id: string;
   url: string;
   title?: string;
 }
@@ -16,7 +17,7 @@ interface ImageStore {
   createFolder: (name?: string) => void;
   renameFolder: (oldName: string, newName: string) => void;
   deleteFolder: (folderName: string) => void;
-  addImage: (folderName: string, url: string, title?: string) => void;
+  addImage: (folderName: string, url: string, title?: string) => boolean;
   deleteImage: (folderName: string, image: Image) => void;
 }
 
@@ -25,6 +26,7 @@ const DEFAULT_FOLDERS: ImageFolder[] = [
     folderName: 'Goblins',
     images: [
       {
+        id: crypto.randomUUID(),
         url: 'https://legendary-digital-network-assets.s3.amazonaws.com/geekandsundry/wp-content/uploads/2016/11/goblin-step1.png'
       }
     ]
@@ -33,8 +35,21 @@ const DEFAULT_FOLDERS: ImageFolder[] = [
 
 export const STORE_KEY = 'dm-screen/images';
 
-export function migrateImageStore(state: unknown, _version: number): { folders: ImageFolder[] } {
-  return state as { folders: ImageFolder[] };
+export function migrateImageStore(state: unknown, version: number): { folders: ImageFolder[] } {
+  let s = state as { folders: ImageFolder[] };
+  if (version < 1) {
+    // Stamp a stable UUID onto any image that was saved before id was added.
+    s = {
+      ...s,
+      folders: s.folders.map((f) => ({
+        ...f,
+        images: f.images.map((img) =>
+          (img as Image).id ? img : { ...img, id: crypto.randomUUID() }
+        )
+      }))
+    };
+  }
+  return s;
 }
 
 export const useImageStore = create<ImageStore>()(
@@ -66,25 +81,32 @@ export const useImageStore = create<ImageStore>()(
       },
 
       addImage: (folderName, url, title) => {
-        if (!url) return;
+        if (!url) return false;
+        const folder = get().folders.find((f) => f.folderName === folderName);
+        if (folder?.images.some((i) => i.url === url)) return false;
         set({
           folders: get().folders.map((f) =>
-            f.folderName === folderName ? { ...f, images: [...f.images, { url, title }] } : f
+            f.folderName === folderName
+              ? { ...f, images: [...f.images, { id: crypto.randomUUID(), url, title }] }
+              : f
           )
         });
+        return true;
       },
 
       deleteImage: (folderName, image) => {
         set({
           folders: get().folders.map((f) =>
-            f.folderName === folderName ? { ...f, images: f.images.filter((i) => i !== image) } : f
+            f.folderName === folderName
+              ? { ...f, images: f.images.filter((i) => i.id !== image.id) }
+              : f
           )
         });
       }
     }),
     {
       name: STORE_KEY,
-      version: 0,
+      version: 1,
       migrate: migrateImageStore
     }
   )


### PR DESCRIPTION
## What

- **D-1** — Images now have a stable `id` (`crypto.randomUUID()`). `addImage` returns `false` and surfaces an inline error in `AddImageDialog` when the URL already exists in the folder. `deleteImage` uses ID equality instead of reference equality. Store version bumped to 1 with a migration that stamps UUIDs onto any existing images.
- **D-2** — `Character.id` migrated from `number` to `string` (UUID). Store version bumped to 1 with a migration that coerces legacy numeric IDs to strings.
- **D-3** — Local `fmtBonus` in `open5eSearchDialog` moved to `lib/utils.ts` as `formatBonus` and exported.
- **Bug fix** — Accordion content was clipped after adding the first image to a folder. Root cause: `h-(--radix-accordion-content-height)` on the inner `AccordionContent` div pinned the height to a stale CSS variable. Removed the constraint; the open/close animation is on the outer Radix element and is unaffected.

## Migration safety

Both migrations are covered by contract tests in `src/store/__tests__/migrations.test.ts`. Each test freezes the pre-migration snapshot and asserts the post-migration shape — these run in the pre-commit hook.

## Test plan

- [x] Open Manage Images, create a folder, add an image — "Add Image" button remains visible without a refresh
- [x] Try adding the same image URL twice to the same folder — inline error appears in the dialog
- [x] Delete an image, confirm it removes the correct one
- [x] Open Manage Characters — existing characters load correctly; edit and delete work
- [x] Export data, clear localStorage, import — both stores migrate cleanly on reload
- [x] `npm test -- --run` passes (8 tests)