### PR TITLE
feat: Add from DDB stat block import

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Two GitHub Actions secrets are required for the deploy workflow:
 
 - ~~**Import confirmation** — Before `importData()` runs, warn the user that all current data will be overwritten.~~ ✅
 
+## Known Limitations
+
+- **DDB import — compound speed** (`src/lib/ddbParser.ts`): the parser reads speed from a single `.mon-stat-block__attribute-data-value` span. DDB currently puts the full string (e.g. `40 ft., Fly 80 ft., Swim 40 ft.`) in one span, so this works. If DDB ever splits compound speeds across multiple spans, only the first value would be captured.
+
 ## Why not a VTT?
 
 This is for physical tabletop play. The table is the VTT. This tool exists to give the DM a second screen without the complexity of Roll20, Foundry, or Owlbear Rodeo — which are all built around digital maps and tokens.

--- a/src/components/encounters/ddbImportDialog.tsx
+++ b/src/components/encounters/ddbImportDialog.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { StatBlock } from '../../store/encounterStore';
+import { parseDdbStatBlock } from '../../lib/ddbParser';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (partial: Omit<StatBlock, 'id'>) => void;
+}
+
+export default function DdbImportDialog({ isOpen, onClose, onSelect }: Props) {
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className='max-w-md'>
+        <DialogHeader>
+          <DialogTitle>Import from D&amp;D Beyond</DialogTitle>
+        </DialogHeader>
+        <div className='space-y-3'>
+          <p className='text-sm text-muted-foreground'>
+            Go to a monster page on D&amp;D Beyond, select all stat block content, copy it, then
+            paste below.
+          </p>
+          <Textarea
+            autoFocus
+            placeholder='Paste here…'
+            className='text-sm resize-none h-10'
+            onPaste={(e) => {
+              e.preventDefault();
+              setError(null);
+              if (!e.clipboardData.types.includes('text/html')) {
+                setError(
+                  "Couldn't find a D&D Beyond stat block. Make sure you've copied from a monster page."
+                );
+                return;
+              }
+              const result = parseDdbStatBlock(e.clipboardData.getData('text/html'));
+              if (!result) {
+                setError(
+                  "Couldn't find a D&D Beyond stat block. Make sure you've copied from a monster page."
+                );
+                return;
+              }
+              onSelect(result);
+              handleClose();
+            }}
+          />
+          {error && <p className='text-sm text-destructive'>{error}</p>}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/encounters/manage-stat-blocks-panel.tsx
+++ b/src/components/encounters/manage-stat-blocks-panel.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Trash2, Plus, Search, GripVertical } from 'lucide-react';
+import { Trash2, Plus, Search, GripVertical, Clipboard } from 'lucide-react';
 import { StatBlock, useEncounterStore } from '../../store/encounterStore';
 import Open5eSearchDialog from './open5eSearchDialog';
+import DdbImportDialog from './ddbImportDialog';
 import StatBlockEditorPanel from './statBlockEditorPanel';
 import StatBlockCard from './statBlockCard';
 import DeleteConfirmDialog from '@/components/ui/delete-confirm-dialog';
@@ -46,6 +47,7 @@ export default function ManageStatBlocksPanel() {
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isDdbOpen, setIsDdbOpen] = useState(false);
   const { target: deleteTarget, requestDelete, clearDelete } = useConfirmDelete<StatBlock>();
 
   const selected = statBlocks.find((s) => s.id === selectedId) ?? null;
@@ -75,6 +77,11 @@ export default function ManageStatBlocksPanel() {
       <Open5eSearchDialog
         isOpen={isSearchOpen}
         onClose={() => setIsSearchOpen(false)}
+        onSelect={handleImport}
+      />
+      <DdbImportDialog
+        isOpen={isDdbOpen}
+        onClose={() => setIsDdbOpen(false)}
         onSelect={handleImport}
       />
       <div className='flex flex-1 min-h-0'>
@@ -122,6 +129,14 @@ export default function ManageStatBlocksPanel() {
               onClick={() => setIsSearchOpen(true)}>
               <Search className='h-4 w-4 mr-1' />
               Add from Open5e
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              className='w-full'
+              onClick={() => setIsDdbOpen(true)}>
+              <Clipboard className='h-4 w-4 mr-1' />
+              Add from DDB
             </Button>
             <Button variant='outline' size='sm' className='w-full' onClick={handleAddManual}>
               <Plus className='h-4 w-4 mr-1' />

--- a/src/components/encounters/statBlockCard.tsx
+++ b/src/components/encounters/statBlockCard.tsx
@@ -119,31 +119,42 @@ export default function StatBlockCard({ statBlock: sb }: Props) {
         </div>
       )}
 
-      {/* Body markdown — two-column flow */}
+      {/* Body markdown — two-column flow, one section per wrapper to avoid mid-section breaks */}
       {hasBody && (
         <div style={{ columns: '2', columnGap: '1.5rem' }}>
-          <ReactMarkdown
-            components={{
-              h2: ({ children }) => (
-                <h2 className='text-xl font-bold uppercase tracking-wide mt-3 first:mt-0 mb-1 border-b border-foreground/20 pb-0.5 break-after-avoid'>
-                  {children}
-                </h2>
-              ),
-              p: ({ children }) => (
-                <p className='text-sm font-light mb-1.5 leading-snug break-inside-avoid'>
-                  {children}
-                </p>
-              ),
-              strong: ({ children }) => <strong className='font-bold'>{children}</strong>,
-              em: ({ children }) => <em>{children}</em>,
-              a: ({ href, children }) => (
-                <a href={href} target='_blank' rel='noopener noreferrer' className='underline'>
-                  {children}
-                </a>
-              )
-            }}>
-            {sb.body}
-          </ReactMarkdown>
+          {sb
+            .body!.split(/(?=^## )/m)
+            .filter((s) => s.trim())
+            .map((section, i) => (
+              <div key={i} style={{ breakInside: 'avoid' }} className={i > 0 ? 'mt-3' : ''}>
+                <ReactMarkdown
+                  components={{
+                    h2: ({ children }) => (
+                      <h2 className='text-xl font-bold uppercase tracking-wide mb-1 border-b border-foreground/20 pb-0.5 break-after-avoid'>
+                        {children}
+                      </h2>
+                    ),
+                    p: ({ children }) => (
+                      <p className='text-sm font-light mb-1.5 leading-snug break-inside-avoid'>
+                        {children}
+                      </p>
+                    ),
+                    strong: ({ children }) => <strong className='font-bold'>{children}</strong>,
+                    em: ({ children }) => <em>{children}</em>,
+                    a: ({ href, children }) => (
+                      <a
+                        href={href}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        className='underline'>
+                        {children}
+                      </a>
+                    )
+                  }}>
+                  {section}
+                </ReactMarkdown>
+              </div>
+            ))}
         </div>
       )}
     </div>

--- a/src/components/encounters/statBlockEditorPanel.tsx
+++ b/src/components/encounters/statBlockEditorPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import TurndownService from 'turndown';
 import { StatBlock } from '../../store/encounterStore';
+import { htmlToMarkdown } from '../../lib/ddbParser';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
@@ -37,24 +37,6 @@ function Field({
       />
     </div>
   );
-}
-
-const td = new TurndownService({ headingStyle: 'atx' });
-td.addRule('flatten-headings', {
-  filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-  replacement: (content) => `\n\n## ${content}\n\n`
-});
-td.addRule('ddb-section-headings', {
-  filter: (node) =>
-    node.nodeName === 'DIV' &&
-    (node as Element).classList?.contains('mon-stat-block__description-block-heading'),
-  replacement: (content) => `\n\n## ${content.trim()}\n\n`
-});
-function htmlToMarkdown(html: string): string {
-  let md = td.turndown(html).trim();
-  // DDB often puts trait names in their own <p>: "***Name.***\n\nDesc" → "***Name.*** Desc"
-  md = md.replace(/(\*{2,3}[^*\n]+\*{2,3})\n\n([^#\n])/g, '$1 $2');
-  return md;
 }
 
 export default function StatBlockEditorPanel({ statBlock: sb, onChange }: Props) {

--- a/src/lib/__tests__/ddbParser.test.ts
+++ b/src/lib/__tests__/ddbParser.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import { parseDdbStatBlock } from '../ddbParser';
+
+const DRUID_HTML = `
+<div class="mon-stat-block">
+  <div class="mon-stat-block__header">
+    <div class="mon-stat-block__name">
+      <a class="mon-stat-block__name-link" href="/monsters/16848-druid">Druid</a>
+    </div>
+    <div class="mon-stat-block__meta">Medium Humanoid (Any Race), Any Alignment</div>
+  </div>
+  <div class="mon-stat-block__attributes">
+    <div class="mon-stat-block__attribute">
+      <span class="mon-stat-block__attribute-label">Armor Class</span>
+      <span class="mon-stat-block__attribute-value">
+        <span class="mon-stat-block__attribute-data-value">11</span>
+        <span class="mon-stat-block__attribute-data-extra">(16 with barkskin)</span>
+      </span>
+    </div>
+    <div class="mon-stat-block__attribute">
+      <span class="mon-stat-block__attribute-label">Hit Points</span>
+      <span class="mon-stat-block__attribute-data">
+        <span class="mon-stat-block__attribute-data-value">27</span>
+        <span class="mon-stat-block__attribute-data-extra">(5d8 + 5)</span>
+      </span>
+    </div>
+    <div class="mon-stat-block__attribute">
+      <span class="mon-stat-block__attribute-label">Speed</span>
+      <span class="mon-stat-block__attribute-data">
+        <span class="mon-stat-block__attribute-data-value">30 ft.</span>
+      </span>
+    </div>
+  </div>
+  <div class="ability-block">
+    <div class="ability-block__stat ability-block__stat--str">
+      <div class="ability-block__data"><span class="ability-block__score">10</span></div>
+    </div>
+    <div class="ability-block__stat ability-block__stat--dex">
+      <div class="ability-block__data"><span class="ability-block__score">12</span></div>
+    </div>
+    <div class="ability-block__stat ability-block__stat--con">
+      <div class="ability-block__data"><span class="ability-block__score">13</span></div>
+    </div>
+    <div class="ability-block__stat ability-block__stat--int">
+      <div class="ability-block__data"><span class="ability-block__score">12</span></div>
+    </div>
+    <div class="ability-block__stat ability-block__stat--wis">
+      <div class="ability-block__data"><span class="ability-block__score">15</span></div>
+    </div>
+    <div class="ability-block__stat ability-block__stat--cha">
+      <div class="ability-block__data"><span class="ability-block__score">11</span></div>
+    </div>
+  </div>
+  <div class="mon-stat-block__tidbits">
+    <div class="mon-stat-block__tidbit">
+      <span class="mon-stat-block__tidbit-label">Skills</span>
+      <span class="mon-stat-block__tidbit-data">Medicine +4, Nature +3, Perception +4</span>
+    </div>
+    <div class="mon-stat-block__tidbit">
+      <span class="mon-stat-block__tidbit-label">Senses</span>
+      <span class="mon-stat-block__tidbit-data">Passive Perception 14</span>
+    </div>
+    <div class="mon-stat-block__tidbit">
+      <span class="mon-stat-block__tidbit-label">Languages</span>
+      <span class="mon-stat-block__tidbit-data">Druidic plus any two languages</span>
+    </div>
+    <div class="mon-stat-block__tidbit">
+      <span class="mon-stat-block__tidbit-label">Proficiency Bonus</span>
+      <span class="mon-stat-block__tidbit-data">+2</span>
+    </div>
+  </div>
+  <div class="mon-stat-block__description-blocks">
+    <div class="mon-stat-block__description-block">
+      <div class="mon-stat-block__description-block-heading">Actions</div>
+      <div class="mon-stat-block__description-block-content">
+        <p><em><strong>Quarterstaff.</strong> Melee Weapon Attack:</em> +2 to hit, one target.</p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+describe('parseDdbStatBlock', () => {
+  it('returns null for non-DDB HTML', () => {
+    expect(parseDdbStatBlock('<div class="something-else">nope</div>')).toBeNull();
+    expect(parseDdbStatBlock('<p>plain text</p>')).toBeNull();
+    expect(parseDdbStatBlock('')).toBeNull();
+  });
+
+  it('parses name and builds sourceUrl from a relative href', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.name).toBe('Druid');
+    expect(result?.sourceUrl).toBe('https://www.dndbeyond.com/monsters/16848-druid');
+  });
+
+  it('uses an absolute href as-is without doubling the domain', () => {
+    const html = DRUID_HTML.replace(
+      'href="/monsters/16848-druid"',
+      'href="https://www.dndbeyond.com/monsters/16848-druid"'
+    );
+    expect(parseDdbStatBlock(html)?.sourceUrl).toBe(
+      'https://www.dndbeyond.com/monsters/16848-druid'
+    );
+  });
+
+  it('parses size and creatureType from meta, dropping alignment', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.size).toBe('Medium');
+    expect(result?.creatureType).toBe('Humanoid (Any Race)');
+  });
+
+  it('parses AC, acDesc, HP, hitDice, and speed', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.ac).toBe(11);
+    expect(result?.acDesc).toBe('16 with barkskin');
+    expect(result?.hp).toBe(27);
+    expect(result?.hitDice).toBe('5d8 + 5');
+    expect(result?.speed).toBe('30 ft.');
+  });
+
+  it('parses all six ability scores', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.str).toBe(10);
+    expect(result?.dex).toBe(12);
+    expect(result?.con).toBe(13);
+    expect(result?.int).toBe(12);
+    expect(result?.wis).toBe(15);
+    expect(result?.cha).toBe(11);
+  });
+
+  it('parses tidbits', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.skills).toBe('Medicine +4, Nature +3, Perception +4');
+    expect(result?.senses).toBe('Passive Perception 14');
+    expect(result?.languages).toBe('Druidic plus any two languages');
+    expect(result?.proficiencyBonus).toBe(2);
+  });
+
+  it('parses body from description blocks', () => {
+    const result = parseDdbStatBlock(DRUID_HTML);
+    expect(result?.body).toContain('## Actions');
+    expect(result?.body).toContain('Quarterstaff');
+  });
+
+  it('accepts HTML copied without the outer mon-stat-block wrapper', () => {
+    const withoutWrapper = DRUID_HTML.replace('<div class="mon-stat-block">', '').replace(
+      /^[\s\S]*?(?=<div class="mon-stat-block__header")/,
+      ''
+    );
+    const result = parseDdbStatBlock(withoutWrapper);
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('Druid');
+  });
+});

--- a/src/lib/ddbParser.ts
+++ b/src/lib/ddbParser.ts
@@ -1,0 +1,124 @@
+import TurndownService from 'turndown';
+import { StatBlock } from '../store/encounterStore';
+
+const td = new TurndownService({ headingStyle: 'atx' });
+td.addRule('flatten-headings', {
+  filter: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+  replacement: (content) => `\n\n## ${content}\n\n`
+});
+td.addRule('ddb-section-headings', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as Element).classList?.contains('mon-stat-block__description-block-heading'),
+  replacement: (content) => `\n\n## ${content.trim()}\n\n`
+});
+td.addRule('italic-links', {
+  filter: (node) => node.nodeName === 'A' && (node as HTMLElement).style?.fontStyle === 'italic',
+  replacement: (content, node) => {
+    const href = (node as HTMLElement).getAttribute('href') ?? '';
+    return href ? `*[${content}](${href})*` : `*${content}*`;
+  }
+});
+
+export function htmlToMarkdown(html: string): string {
+  let md = td.turndown(html).trim();
+  md = md.replace(/(\*{2,3}[^*\n]+\*{2,3})\n\n([^#\n])/g, '$1 $2');
+  return md;
+}
+
+export function parseDdbStatBlock(html: string): Omit<StatBlock, 'id'> | null {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  if (!doc.querySelector('.mon-stat-block') && !doc.querySelector('.mon-stat-block__header')) {
+    return null;
+  }
+
+  const text = (sel: string) => doc.querySelector(sel)?.textContent?.trim() ?? '';
+
+  const nameLink = doc.querySelector('a.mon-stat-block__name-link');
+  const name = nameLink?.textContent?.trim() || 'New Creature';
+  const href = nameLink?.getAttribute('href') ?? '';
+  const sourceUrl = href
+    ? href.startsWith('http')
+      ? href
+      : `https://www.dndbeyond.com${href}`
+    : undefined;
+
+  const meta = text('.mon-stat-block__meta').split(',')[0].trim();
+  const spaceIdx = meta.indexOf(' ');
+  const size = spaceIdx > -1 ? meta.slice(0, spaceIdx) : undefined;
+  const creatureType = spaceIdx > -1 ? meta.slice(spaceIdx + 1).trim() : undefined;
+
+  let ac: number | undefined, acDesc: string | undefined;
+  let hp = 0,
+    hitDice: string | undefined;
+  let speed: string | undefined;
+
+  doc.querySelectorAll('.mon-stat-block__attribute').forEach((el) => {
+    const label = el.querySelector('.mon-stat-block__attribute-label')?.textContent?.trim();
+    const val = el.querySelector('.mon-stat-block__attribute-data-value')?.textContent?.trim();
+    const extra = el
+      .querySelector('.mon-stat-block__attribute-data-extra')
+      ?.textContent?.trim()
+      .replace(/[()]/g, '')
+      .trim();
+    if (label === 'Armor Class') {
+      ac = val ? parseInt(val) : undefined;
+      acDesc = extra || undefined;
+    } else if (label === 'Hit Points') {
+      hp = val ? parseInt(val) : 0;
+      hitDice = extra || undefined;
+    } else if (label === 'Speed') {
+      speed = val || undefined;
+    }
+  });
+
+  const score = (s: string) => {
+    const v = doc
+      .querySelector(`.ability-block__stat--${s} .ability-block__score`)
+      ?.textContent?.trim();
+    return v ? parseInt(v) : undefined;
+  };
+
+  const tidbits: Record<string, string> = {};
+  doc.querySelectorAll('.mon-stat-block__tidbit').forEach((el) => {
+    const label = el.querySelector('.mon-stat-block__tidbit-label')?.textContent?.trim();
+    const data = el
+      .querySelector('.mon-stat-block__tidbit-data')
+      ?.textContent?.trim()
+      .replace(/\s+/g, ' ');
+    if (label && data) tidbits[label] = data;
+  });
+  const td2 = (key: string) => tidbits[key] || undefined;
+  const profBonus = td2('Proficiency Bonus');
+
+  const descEl = doc.querySelector('.mon-stat-block__description-blocks');
+  const body = descEl ? htmlToMarkdown(descEl.outerHTML) || undefined : undefined;
+
+  return {
+    name,
+    size,
+    creatureType,
+    sourceUrl,
+    ac,
+    acDesc,
+    hp,
+    hitDice,
+    speed,
+    str: score('str'),
+    dex: score('dex'),
+    con: score('con'),
+    int: score('int'),
+    wis: score('wis'),
+    cha: score('cha'),
+    savingThrows: td2('Saving Throws'),
+    skills: td2('Skills'),
+    damageVulnerabilities: td2('Damage Vulnerabilities'),
+    damageResistances: td2('Damage Resistances'),
+    damageImmunities: td2('Damage Immunities'),
+    conditionImmunities: td2('Condition Immunities'),
+    senses: td2('Senses'),
+    languages: td2('Languages'),
+    proficiencyBonus: profBonus ? parseInt(profBonus.replace('+', '')) : undefined,
+    body
+  };
+}


### PR DESCRIPTION
## What

Adds a third stat block import path in **Prep → NPCs** alongside the existing Open5e search and manual entry. The user copies HTML from a D&D Beyond monster page, clicks **Add from DDB**, pastes into the dialog, and the new stat block opens immediately in the editor.

## How it works

**Paste flow:**
1. User opens the dialog (textarea is auto-focused — paste immediately without clicking)
2. `onPaste` reads `text/html` from the clipboard via `ClipboardEvent.clipboardData` — no browser permission prompt required
3. `parseDdbStatBlock` parses the HTML and returns a typed `Omit<StatBlock, 'id'>` or `null`
4. On success: dialog closes, stat block is added and selected, editor opens
5. On failure: inline error shown, dialog stays open

**Parser handles:**
- HTML copied with the outer `.mon-stat-block` wrapper OR just the inner content (the more common case — users typically select inside the block)
- Relative hrefs (`/monsters/...`) and absolute hrefs (`https://www.dndbeyond.com/monsters/...`) without doubling the domain
- Tidbit labels via `.textContent` so linked terms (skills, conditions) resolve to plain text
- DDB spell links with CSS-applied italic (`font-style: italic` inline style) — converted to `*[name](url)*` markdown so they render italic + linked
- Body sections piped through `htmlToMarkdown` (TurndownService with DDB-specific rules)

## Changes

| File | Change |
|---|---|
| `src/lib/ddbParser.ts` | New shared module — `htmlToMarkdown` (moved from `statBlockEditorPanel`) + `parseDdbStatBlock` |
| `src/components/encounters/ddbImportDialog.tsx` | New paste-target dialog, mirrors `open5eSearchDialog` prop pattern |
| `src/components/encounters/manage-stat-blocks-panel.tsx` | Wires in `DdbImportDialog` + "Add from DDB" button |
| `src/components/encounters/statBlockEditorPanel.tsx` | Imports `htmlToMarkdown` from shared module instead of defining it locally |
| `src/components/encounters/statBlockCard.tsx` | Splits body markdown into per-section wrappers with `break-inside: avoid` — CSS column breaks now only occur between sections, never mid-content |
| `src/lib/__tests__/ddbParser.test.ts` | 8 tests covering null guard, name/URL, relative vs absolute hrefs, meta parsing, combat stats, ability scores, tidbits, body content, and the no-wrapper copy case |
| `README.md` | Adds Known Limitations section noting the single-span speed assumption |

## Design decisions

- **No confirmation step** — on successful parse, dialog closes and editor opens immediately. The stat block is editable and deletable in one click, so the cost of a wrong paste is low. Matches the Open5e flow.
- **Clipboard API not used** — `navigator.clipboard.read()` requires a `clipboard-read` permission prompt and has inconsistent `text/html` support across browsers. The paste event's `clipboardData` gives full HTML access with no prompt.
- **Dice roll spans not highlighted** — explored wrapping `data-dicenotation` spans in inline code, but the density of roll spans (4–5 per paragraph on complex monsters) was visually noisy with no meaningful payoff. Parentheses already distinguish dice expressions.

## Testing

- `npm test` — 48 tests, all passing (7 test files)
- Manual: imported Druid and Adult Black Dragon from DDB; all fields parsed correctly, body sections stay within columns, spell names render italic + linked