### PR TITLE
feat: markdown notes view/edit toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,5 @@ Each store that participates in export/import exports `STORE_KEY` and a `migrate
 **Export/Import**: Header dropdown → `exportData()` writes the 5 backed-up stores to a dated JSON file; `importData(file)` restores them to localStorage and reloads the page so Zustand's `migrate` pipeline runs on the new data.
 
 **Campaigns**: Each campaign has a `slug` (URL-safe name + 4-char UUID suffix) that becomes the PartyKit room name. `GoLiveButton` connects as `'dm'` role; players connect via `/players/:slug`. Changing a campaign's slug changes the room — share the new URL with players.
+
+**Notes**: `characters.tsx` renders notes in two modes. Read mode renders the raw string via `react-markdown`; double-click (or Esc/blur from edit mode) transitions between them. Save is explicit — Save button, blur, or Esc — no debounce autosave. The store still holds a plain string; markdown is display-only.

--- a/src/components/characters/characters.tsx
+++ b/src/components/characters/characters.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 import PlayerDetails from './playerDetails';
-import { Textarea } from '@/components/ui/textarea';
 import SectionHeader from '@/components/ui/section-header';
+import { Button } from '@/components/ui/button';
 import { useCharacterStore } from '../../store/characterStore';
 import { useNotesStore } from '../../store/notesStore';
 import { useCampaignStore } from '../../store/campaignStore';
@@ -15,43 +16,107 @@ export default function Characters() {
   const notes = useNotesStore((s) => s.notes);
   const setNotes = useNotesStore((s) => s.setNotes);
 
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
   const [savedVisible, setSavedVisible] = useState(false);
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleNotesChange = (value: string) => {
-    setNotes(value);
-    if (saveTimer.current) clearTimeout(saveTimer.current);
+  const showSaved = () => {
+    setSavedVisible(true);
     if (fadeTimer.current) clearTimeout(fadeTimer.current);
-    saveTimer.current = setTimeout(() => {
-      setSavedVisible(true);
-      fadeTimer.current = setTimeout(() => setSavedVisible(false), 1500);
-    }, 800);
+    fadeTimer.current = setTimeout(() => setSavedVisible(false), 1500);
+  };
+
+  const handleSave = () => {
+    setNotes(editValue);
+    setIsEditing(false);
+    showSaved();
+  };
+
+  const handleEnterEdit = () => {
+    setEditValue(notes);
+    setIsEditing(true);
   };
 
   return (
-    <div className='space-y-4'>
-      <section>
+    <div className='flex flex-col flex-1 min-h-0 gap-4'>
+      <section className='shrink-0'>
         <SectionHeader className='mb-2'>Characters</SectionHeader>
         <PlayerDetails characters={characters} />
       </section>
 
-      <section>
+      <section className='flex flex-col flex-1 min-h-0'>
         <div className='flex items-center justify-between mb-2'>
           <SectionHeader>Notes</SectionHeader>
-          <span
-            className={`text-xs text-muted-foreground transition-opacity duration-500 ${
-              savedVisible ? 'opacity-100' : 'opacity-0'
-            }`}>
-            Saved
-          </span>
+          <div className='flex items-center gap-2'>
+            {isEditing && (
+              <Button size='sm' onMouseDown={(e) => e.preventDefault()} onClick={handleSave}>
+                Save
+              </Button>
+            )}
+            <span
+              className={`text-xs text-muted-foreground transition-opacity duration-500 ${
+                savedVisible ? 'opacity-100' : 'opacity-0'
+              }`}>
+              Saved
+            </span>
+          </div>
         </div>
-        <Textarea
-          value={notes}
-          onChange={(e) => handleNotesChange(e.target.value)}
-          placeholder='Session notes…'
-          className='min-h-32 resize-y text-sm font-mono'
-        />
+
+        {isEditing ? (
+          <textarea
+            autoFocus
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onKeyDown={(e) => e.key === 'Escape' && handleSave()}
+            onBlur={handleSave}
+            className='flex-1 min-h-0 overflow-y-auto w-full resize-none rounded-md border border-input bg-background px-3 py-2 text-sm font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+          />
+        ) : (
+          <div
+            onDoubleClick={handleEnterEdit}
+            className='flex-1 min-h-0 overflow-y-auto rounded-md border border-input bg-background px-3 py-2 text-sm cursor-text'>
+            {notes ? (
+              <ReactMarkdown
+                components={{
+                  h1: ({ children }) => (
+                    <h1 className='text-lg font-bold mb-2 mt-3 first:mt-0'>{children}</h1>
+                  ),
+                  h2: ({ children }) => (
+                    <h2 className='text-base font-bold mb-1.5 mt-3 first:mt-0'>{children}</h2>
+                  ),
+                  h3: ({ children }) => (
+                    <h3 className='text-sm font-semibold mb-1 mt-2 first:mt-0'>{children}</h3>
+                  ),
+                  p: ({ children }) => <p className='mb-2 last:mb-0 leading-relaxed'>{children}</p>,
+                  ul: ({ children }) => (
+                    <ul className='list-disc pl-4 mb-2 space-y-0.5'>{children}</ul>
+                  ),
+                  ol: ({ children }) => (
+                    <ol className='list-decimal pl-4 mb-2 space-y-0.5'>{children}</ol>
+                  ),
+                  li: ({ children }) => <li className='leading-relaxed'>{children}</li>,
+                  strong: ({ children }) => <strong className='font-semibold'>{children}</strong>,
+                  em: ({ children }) => <em className='italic'>{children}</em>,
+                  code: ({ children }) => (
+                    <code className='bg-muted px-1 py-0.5 rounded text-xs font-mono'>
+                      {children}
+                    </code>
+                  ),
+                  hr: () => <hr className='border-border my-3' />,
+                  blockquote: ({ children }) => (
+                    <blockquote className='border-l-2 border-muted-foreground/40 pl-3 italic text-muted-foreground my-2'>
+                      {children}
+                    </blockquote>
+                  )
+                }}>
+                {notes}
+              </ReactMarkdown>
+            ) : (
+              <span className='text-muted-foreground'>Session notes…</span>
+            )}
+          </div>
+        )}
       </section>
     </div>
   );

--- a/src/components/characters/characters.tsx
+++ b/src/components/characters/characters.tsx
@@ -1,11 +1,35 @@
-import { useRef, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
+import { useEffect, useRef, useState } from 'react';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import PlayerDetails from './playerDetails';
 import SectionHeader from '@/components/ui/section-header';
 import { Button } from '@/components/ui/button';
 import { useCharacterStore } from '../../store/characterStore';
 import { useNotesStore } from '../../store/notesStore';
 import { useCampaignStore } from '../../store/campaignStore';
+
+const MD_COMPONENTS: Components = {
+  h1: ({ children }) => <h1 className='text-lg font-bold mb-2 mt-3 first:mt-0'>{children}</h1>,
+  h2: ({ children }) => <h2 className='text-base font-bold mb-1.5 mt-3 first:mt-0'>{children}</h2>,
+  h3: ({ children }) => <h3 className='text-sm font-semibold mb-1 mt-2 first:mt-0'>{children}</h3>,
+  p: ({ children }) => <p className='mb-2 last:mb-0 leading-relaxed'>{children}</p>,
+  ul: ({ children }) => <ul className='list-disc pl-4 mb-2 space-y-0.5'>{children}</ul>,
+  ol: ({ children }) => <ol className='list-decimal pl-4 mb-2 space-y-0.5'>{children}</ol>,
+  li: ({ children }) => <li className='leading-relaxed'>{children}</li>,
+  strong: ({ children }) => <strong className='font-semibold'>{children}</strong>,
+  em: ({ children }) => <em className='italic'>{children}</em>,
+  pre: ({ children }) => (
+    <pre className='bg-muted rounded p-2 overflow-x-auto text-xs font-mono my-2'>{children}</pre>
+  ),
+  code: ({ children }) => (
+    <code className='bg-muted px-1 py-0.5 rounded text-xs font-mono'>{children}</code>
+  ),
+  hr: () => <hr className='border-border my-3' />,
+  blockquote: ({ children }) => (
+    <blockquote className='border-l-2 border-muted-foreground/40 pl-3 italic text-muted-foreground my-2'>
+      {children}
+    </blockquote>
+  )
+};
 
 export default function Characters() {
   const allCharacters = useCharacterStore((s) => s.characters);
@@ -19,7 +43,17 @@ export default function Characters() {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const [savedVisible, setSavedVisible] = useState(false);
+  const [undoValue, setUndoValue] = useState<string | null>(null);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const undoTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (fadeTimer.current) clearTimeout(fadeTimer.current);
+      if (undoTimer.current) clearTimeout(undoTimer.current);
+    },
+    []
+  );
 
   const showSaved = () => {
     setSavedVisible(true);
@@ -28,9 +62,19 @@ export default function Characters() {
   };
 
   const handleSave = () => {
+    setUndoValue(notes);
     setNotes(editValue);
     setIsEditing(false);
     showSaved();
+    if (undoTimer.current) clearTimeout(undoTimer.current);
+    undoTimer.current = setTimeout(() => setUndoValue(null), 60000);
+  };
+
+  const handleUndo = () => {
+    if (undoValue === null) return;
+    setNotes(undoValue);
+    setUndoValue(null);
+    if (undoTimer.current) clearTimeout(undoTimer.current);
   };
 
   const handleEnterEdit = () => {
@@ -53,6 +97,13 @@ export default function Characters() {
               <Button size='sm' onMouseDown={(e) => e.preventDefault()} onClick={handleSave}>
                 Save
               </Button>
+            )}
+            {!isEditing && undoValue !== null && (
+              <button
+                onClick={handleUndo}
+                className='text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground'>
+                Undo
+              </button>
             )}
             <span
               className={`text-xs text-muted-foreground transition-opacity duration-500 ${
@@ -77,41 +128,7 @@ export default function Characters() {
             onDoubleClick={handleEnterEdit}
             className='flex-1 min-h-0 overflow-y-auto rounded-md border border-input bg-background px-3 py-2 text-sm cursor-text'>
             {notes ? (
-              <ReactMarkdown
-                components={{
-                  h1: ({ children }) => (
-                    <h1 className='text-lg font-bold mb-2 mt-3 first:mt-0'>{children}</h1>
-                  ),
-                  h2: ({ children }) => (
-                    <h2 className='text-base font-bold mb-1.5 mt-3 first:mt-0'>{children}</h2>
-                  ),
-                  h3: ({ children }) => (
-                    <h3 className='text-sm font-semibold mb-1 mt-2 first:mt-0'>{children}</h3>
-                  ),
-                  p: ({ children }) => <p className='mb-2 last:mb-0 leading-relaxed'>{children}</p>,
-                  ul: ({ children }) => (
-                    <ul className='list-disc pl-4 mb-2 space-y-0.5'>{children}</ul>
-                  ),
-                  ol: ({ children }) => (
-                    <ol className='list-decimal pl-4 mb-2 space-y-0.5'>{children}</ol>
-                  ),
-                  li: ({ children }) => <li className='leading-relaxed'>{children}</li>,
-                  strong: ({ children }) => <strong className='font-semibold'>{children}</strong>,
-                  em: ({ children }) => <em className='italic'>{children}</em>,
-                  code: ({ children }) => (
-                    <code className='bg-muted px-1 py-0.5 rounded text-xs font-mono'>
-                      {children}
-                    </code>
-                  ),
-                  hr: () => <hr className='border-border my-3' />,
-                  blockquote: ({ children }) => (
-                    <blockquote className='border-l-2 border-muted-foreground/40 pl-3 italic text-muted-foreground my-2'>
-                      {children}
-                    </blockquote>
-                  )
-                }}>
-                {notes}
-              </ReactMarkdown>
+              <ReactMarkdown components={MD_COMPONENTS}>{notes}</ReactMarkdown>
             ) : (
               <span className='text-muted-foreground'>Session notes…</span>
             )}

--- a/src/pages/dm-screen.tsx
+++ b/src/pages/dm-screen.tsx
@@ -123,7 +123,7 @@ const DmScreen = () => {
           <TabsTrigger value='images'>Images</TabsTrigger>
         </TabsList>
 
-        <TabsContent value='home' className='flex-1 overflow-auto p-3 mt-0'>
+        <TabsContent value='home' className='flex-1 overflow-hidden flex flex-col p-3 mt-0'>
           <Characters />
         </TabsContent>
 


### PR DESCRIPTION
## Summary

Replace the always-on textarea with a markdown render/edit toggle for session notes.

## What changed

- **`src/components/characters/characters.tsx`** — new read/edit mode pattern for notes
  - Read mode renders notes via `react-markdown` with lightweight inline styles (no typography plugin)
  - Empty state shows a muted "Session notes…" placeholder; still double-clickable to enter edit mode
  - Edit mode: plain `<textarea>` with `autoFocus`, pre-filled with raw markdown string
  - Three ways to save and return to read mode: Save button, blur (click outside), or Esc
  - Save button uses `onMouseDown` + `preventDefault` to block textarea blur on click — prevents double-save
  - Removes debounce autosave; "Saved" indicator now fires on explicit save only
  - After saving, an **Undo** link appears in the notes header for 60 seconds — clicking it restores the pre-save value
  - `MD_COMPONENTS` extracted as a module-level constant (was inline, causing unnecessary re-renders)
  - `fadeTimer` and `undoTimer` cleaned up on unmount
  - Fenced code blocks (`pre`) styled to match the rest of the markdown components
  - Layout updated to `flex flex-col flex-1 min-h-0` so notes fills remaining vertical space; characters section is `shrink-0`
- **`src/pages/dm-screen.tsx`** — home `TabsContent` changed to `overflow-hidden flex flex-col` to support the flex fill layout
- **`CLAUDE.md`** — added Notes entry to Key Flows

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Tested in the browser (dev server)
- [x] No regressions in related features