### PR TITLE
feat: image management enhancements — DnD reorder/move, search, hover preview, edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dm-screen",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@fontsource-variable/geist": "^5.2.9",
         "@tailwindcss/vite": "^4.3.0",
         "class-variance-authority": "^0.7.1",
@@ -655,6 +658,59 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.9",
     "@tailwindcss/vite": "^4.3.0",
     "class-variance-authority": "^0.7.1",

--- a/src/components/images/add-image-dialog.tsx
+++ b/src/components/images/add-image-dialog.tsx
@@ -8,16 +8,19 @@ interface AddImageDialogProps {
   onClose: () => void;
   targetFolder: string;
   onSave: (url: string, title: string) => boolean;
+  initialValues?: { url: string; title: string };
 }
 
 export default function AddImageDialog({
   open,
   onClose,
   targetFolder,
-  onSave
+  onSave,
+  initialValues
 }: AddImageDialogProps) {
-  const [url, setUrl] = useState('');
-  const [imageTitle, setImageTitle] = useState('');
+  const isEdit = !!initialValues;
+  const [url, setUrl] = useState(initialValues?.url ?? '');
+  const [imageTitle, setImageTitle] = useState(initialValues?.title ?? '');
   const [dupeError, setDupeError] = useState(false);
 
   const handleClose = () => {
@@ -41,8 +44,10 @@ export default function AddImageDialog({
     <SimpleDialog
       open={open}
       onClose={handleClose}
-      title='Add Image'
-      description={`Save an image URL to "${targetFolder}".`}
+      title={isEdit ? 'Edit Image' : 'Add Image'}
+      description={
+        isEdit ? `Edit image in "${targetFolder}".` : `Save an image URL to "${targetFolder}".`
+      }
       onSubmit={handleSave}
       submitDisabled={!url.trim()}>
       <div className='space-y-3'>
@@ -52,6 +57,7 @@ export default function AddImageDialog({
             id='add-img-title'
             value={imageTitle}
             onChange={(e: ChangeEvent<HTMLInputElement>) => setImageTitle(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSave()}
             placeholder='Dragon cave map'
           />
         </div>

--- a/src/components/images/folder-list.tsx
+++ b/src/components/images/folder-list.tsx
@@ -1,19 +1,26 @@
+import { useState } from 'react';
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger
 } from '@/components/ui/accordion';
-import { Images } from 'lucide-react';
+import { Images, Send } from 'lucide-react';
 import ImageGrid from './imageGrid';
+import ImageThumbnail from './image-thumbnail';
+import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image, ImageFolder } from '../../store/imageStore';
 
 interface FolderListProps {
   folders: ImageFolder[];
+  search: string;
   onSendImage: (image: Image) => void;
 }
 
-export default function FolderList({ folders, onSendImage }: FolderListProps) {
+export default function FolderList({ folders, search, onSendImage }: FolderListProps) {
+  const [openFolder, setOpenFolder] = useState<string>(folders[0]?.folderName ?? '');
+
   if (folders.length === 0) {
     return (
       <div className='flex flex-col items-center gap-2 py-12 text-muted-foreground'>
@@ -23,31 +30,98 @@ export default function FolderList({ folders, onSendImage }: FolderListProps) {
     );
   }
 
+  const sortedFolders = [...folders].sort((a, b) => a.displayOrder - b.displayOrder);
+
+  if (search) {
+    const term = search.toLowerCase();
+    const matches = sortedFolders.flatMap((folder) =>
+      [...folder.images]
+        .sort((a, b) => a.displayOrder - b.displayOrder)
+        .filter((img) =>
+          img.title ? img.title.toLowerCase().includes(term) : img.url.toLowerCase().includes(term)
+        )
+        .map((img) => ({ img, folderName: folder.folderName }))
+    );
+
+    if (matches.length === 0) {
+      return <p className='text-sm text-muted-foreground py-2'>No matching images.</p>;
+    }
+
+    return (
+      <div className='grid grid-cols-6 gap-2'>
+        {matches.map(({ img, folderName }) => (
+          <HoverCard key={img.id} openDelay={300}>
+            <HoverCardTrigger asChild>
+              <div>
+                <ImageThumbnail
+                  image={img}
+                  imgClassName='w-full h-24 object-cover'
+                  action={
+                    <>
+                      <span className='text-xs text-white/50 truncate flex-1 mr-1'>
+                        {folderName}
+                      </span>
+                      <Button
+                        variant='ghost'
+                        size='icon'
+                        className='h-6 w-6 shrink-0'
+                        onClick={() => onSendImage(img)}>
+                        <Send className='h-3.5 w-3.5' />
+                      </Button>
+                    </>
+                  }
+                />
+              </div>
+            </HoverCardTrigger>
+            <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+              <img
+                src={img.url}
+                alt={img.title}
+                className='w-full rounded object-contain max-h-[70vh]'
+              />
+              {img.title && (
+                <p className='text-xs text-muted-foreground mt-1 truncate'>{img.title}</p>
+              )}
+              <p className='text-xs text-muted-foreground/60 mt-0.5 truncate'>{folderName}</p>
+            </HoverCardContent>
+          </HoverCard>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <Accordion
       type='single'
       collapsible
-      defaultValue={folders[0]?.folderName}
+      value={openFolder}
+      onValueChange={setOpenFolder}
       className='space-y-1'>
-      {folders.map((folder) => (
-        <AccordionItem key={folder.folderName} value={folder.folderName} className='border rounded'>
-          <AccordionTrigger className='px-3 hover:no-underline'>
-            <span className='flex items-center gap-1.5 text-sm font-medium'>
-              {folder.folderName}
-              <span className='text-xs text-muted-foreground font-normal leading-none'>
-                ({folder.images.length})
+      {sortedFolders.map((folder) => {
+        const sortedImages = [...folder.images].sort((a, b) => a.displayOrder - b.displayOrder);
+        return (
+          <AccordionItem
+            key={folder.folderName}
+            value={folder.folderName}
+            className='border rounded'>
+            <AccordionTrigger className='px-3 hover:no-underline'>
+              <span className='flex items-center gap-1.5 text-sm font-medium'>
+                {folder.folderName}
+                <span className='text-xs text-muted-foreground font-normal leading-none'>
+                  ({sortedImages.length})
+                </span>
               </span>
-            </span>
-          </AccordionTrigger>
-          <AccordionContent className='px-3 pb-3'>
-            {folder.images.length > 0 ? (
-              <ImageGrid images={folder.images} onSendImage={onSendImage} />
-            ) : (
-              <p className='text-sm text-muted-foreground py-2'>No images yet.</p>
-            )}
-          </AccordionContent>
-        </AccordionItem>
-      ))}
+            </AccordionTrigger>
+            <AccordionContent className='px-3 pb-3'>
+              {sortedImages.length > 0 ? (
+                <ImageGrid images={sortedImages} onSendImage={onSendImage} />
+              ) : (
+                <p className='text-sm text-muted-foreground py-2'>No images yet.</p>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
     </Accordion>
   );
 }

--- a/src/components/images/imageGrid.tsx
+++ b/src/components/images/imageGrid.tsx
@@ -1,5 +1,6 @@
 import { Send } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image } from '../../store/imageStore';
 import ImageThumbnail from './image-thumbnail';
 
@@ -10,21 +11,37 @@ interface ImageGridProps {
 
 export default function ImageGrid({ images, onSendImage }: ImageGridProps) {
   return (
-    <div className='grid grid-cols-4 gap-2'>
+    <div className='grid grid-cols-6 gap-2'>
       {images.map((image) => (
-        <ImageThumbnail
-          key={image.id}
-          image={image}
-          action={
-            <Button
-              variant='ghost'
-              size='icon'
-              className='h-6 w-6 ml-auto'
-              onClick={() => onSendImage(image)}>
-              <Send className='h-3.5 w-3.5' />
-            </Button>
-          }
-        />
+        <HoverCard key={image.id} openDelay={300}>
+          <HoverCardTrigger asChild>
+            <div>
+              <ImageThumbnail
+                image={image}
+                imgClassName='w-full h-24 object-cover'
+                action={
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='h-6 w-6 ml-auto'
+                    onClick={() => onSendImage(image)}>
+                    <Send className='h-3.5 w-3.5' />
+                  </Button>
+                }
+              />
+            </div>
+          </HoverCardTrigger>
+          <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+            <img
+              src={image.url}
+              alt={image.title}
+              className='w-full rounded object-contain max-h-[70vh]'
+            />
+            {image.title && (
+              <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
+            )}
+          </HoverCardContent>
+        </HoverCard>
       ))}
     </div>
   );

--- a/src/components/images/imageSender.tsx
+++ b/src/components/images/imageSender.tsx
@@ -25,7 +25,7 @@ export default function ImageSender({ onSendImage }: ImageSenderProps) {
     setError(null);
     const img = new window.Image();
     img.onload = () => {
-      onSendImage({ id: crypto.randomUUID(), url });
+      onSendImage({ id: crypto.randomUUID(), url, displayOrder: 0 });
       setImageUrl('');
       setLoading(false);
     };

--- a/src/components/images/images.tsx
+++ b/src/components/images/images.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react';
 import FolderList from './folder-list';
 import ImageSender from './imageSender';
 import { sendMessage } from '../../lib/sync';
 import { useImageStore, Image } from '../../store/imageStore';
 import { useUiStore } from '../../store/uiStore';
 import SectionHeader from '@/components/ui/section-header';
+import { Input } from '@/components/ui/input';
+import { X } from 'lucide-react';
 
 export default function Images() {
   const folders = useImageStore((s) => s.folders);
   const setLastSentImage = useUiStore((s) => s.setLastSentImage);
+  const [search, setSearch] = useState('');
 
   const sendImageToPlayerView = (item: Image) => {
     sendMessage({ cmd: 'image', payload: item });
@@ -23,7 +27,22 @@ export default function Images() {
 
       <section>
         <SectionHeader className='mb-2'>Saved Images</SectionHeader>
-        <FolderList folders={folders} onSendImage={sendImageToPlayerView} />
+        <div className='relative mb-3'>
+          <Input
+            placeholder='Search images…'
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className='pr-8'
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className='absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'>
+              <X className='h-4 w-4' />
+            </button>
+          )}
+        </div>
+        <FolderList folders={folders} search={search} onSendImage={sendImageToPlayerView} />
       </section>
     </div>
   );

--- a/src/components/images/manage-images-panel.tsx
+++ b/src/components/images/manage-images-panel.tsx
@@ -1,4 +1,31 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverEvent,
+  DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  closestCenter,
+  pointerWithin,
+  useDroppable,
+  type CollisionDetection
+} from '@dnd-kit/core';
+
+const collisionDetection: CollisionDetection = (args) => {
+  const pointerHits = pointerWithin(args);
+  if (pointerHits.length > 0) return pointerHits;
+  return closestCenter(args);
+};
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+  rectSortingStrategy
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   Accordion,
   AccordionContent,
@@ -6,8 +33,10 @@ import {
   AccordionTrigger
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Trash2, Pencil, FolderPlus, ImagePlus } from 'lucide-react';
-import { useImageStore, Image } from '../../store/imageStore';
+import { Input } from '@/components/ui/input';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
+import { Trash2, Pencil, FolderPlus, ImagePlus, GripVertical, X } from 'lucide-react';
+import { useImageStore, Image, ImageFolder } from '../../store/imageStore';
 import DeleteConfirmDialog from '@/components/ui/delete-confirm-dialog';
 import { useConfirmDelete } from '@/lib/useConfirmDelete';
 import ImageThumbnail from './image-thumbnail';
@@ -15,7 +44,221 @@ import AddImageDialog from './add-image-dialog';
 import RenameFolderDialog from './rename-folder-dialog';
 import NewFolderDialog from './new-folder-dialog';
 
-type SubDialog = 'addImage' | 'rename' | 'newFolder' | null;
+type SubDialog = 'addImage' | 'rename' | 'newFolder' | 'editImage' | null;
+
+// ── Sortable folder item ────────────────────────────────────────────────────
+
+interface SortableFolderProps {
+  folder: ImageFolder;
+  isDragActive: boolean;
+  activeDragType: 'folder' | 'image' | null;
+  activeImageId: string | null;
+  search: string;
+  onRequestRename: () => void;
+  onRequestDelete: () => void;
+  onRequestAddImage: () => void;
+  onRequestEditImage: (image: Image) => void;
+  onRequestDeleteImage: (image: Image) => void;
+}
+
+function SortableFolder({
+  folder,
+  isDragActive,
+  activeDragType,
+  activeImageId,
+  search,
+  onRequestRename,
+  onRequestDelete,
+  onRequestAddImage,
+  onRequestEditImage,
+  onRequestDeleteImage
+}: SortableFolderProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `folder:${folder.folderName}`,
+    data: { type: 'folder' }
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : undefined
+  };
+
+  // Folder header as a drop target for images being dragged
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: `folder-drop:${folder.folderName}`,
+    data: { type: 'folder-header', folderName: folder.folderName },
+    disabled: activeDragType !== 'image'
+  });
+
+  const sortedImages = [...folder.images].sort((a, b) => a.displayOrder - b.displayOrder);
+  const filteredImages = search
+    ? sortedImages.filter((img) => {
+        const term = search.toLowerCase();
+        return img.title
+          ? img.title.toLowerCase().includes(term)
+          : img.url.toLowerCase().includes(term);
+      })
+    : sortedImages;
+
+  const isImageDragActive = activeDragType === 'image';
+  const showDropHighlight = isImageDragActive && isOver;
+  const showPotentialTarget = isImageDragActive && !isOver;
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <AccordionItem value={folder.folderName} className='border rounded'>
+        <div
+          ref={setDropRef}
+          className={`flex items-center px-3 transition-colors ${showDropHighlight ? 'bg-accent' : showPotentialTarget ? 'bg-muted/50' : ''}`}>
+          <button
+            {...attributes}
+            {...listeners}
+            className='mr-1 cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground focus:outline-none'
+            tabIndex={-1}
+            aria-label='Drag to reorder folder'>
+            <GripVertical className='h-4 w-4' />
+          </button>
+          <AccordionTrigger className='flex-1 hover:no-underline'>
+            <span className='flex items-center gap-1.5 text-sm font-medium'>
+              {folder.folderName}
+              <span className='text-xs text-muted-foreground font-normal leading-none'>
+                {search
+                  ? `(${filteredImages.length} of ${sortedImages.length})`
+                  : `(${sortedImages.length})`}
+              </span>
+            </span>
+          </AccordionTrigger>
+          <div className='flex gap-0.5 shrink-0'>
+            <Button variant='ghost' size='icon' className='h-7 w-7' onClick={onRequestRename}>
+              <Pencil className='h-3.5 w-3.5' />
+            </Button>
+            <Button
+              variant='ghost'
+              size='icon'
+              className='h-7 w-7 text-destructive hover:text-destructive'
+              onClick={onRequestDelete}>
+              <Trash2 className='h-3.5 w-3.5' />
+            </Button>
+          </div>
+        </div>
+
+        <AccordionContent className='px-3 pb-3 space-y-2'>
+          {filteredImages.length > 0 ? (
+            <SortableContext
+              items={filteredImages.map((img) => `image:${img.id}`)}
+              strategy={rectSortingStrategy}>
+              <div className='grid grid-cols-6 gap-2'>
+                {filteredImages.map((image) => (
+                  <SortableImage
+                    key={image.id}
+                    image={image}
+                    folderName={folder.folderName}
+                    isDragActive={isDragActive}
+                    isBeingDragged={activeImageId === image.id}
+                    onRequestEdit={() => onRequestEditImage(image)}
+                    onRequestDelete={() => onRequestDeleteImage(image)}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          ) : (
+            <p className='text-sm text-muted-foreground py-1'>
+              {search ? 'No matching images.' : 'No images yet.'}
+            </p>
+          )}
+          <Button variant='outline' size='sm' onClick={onRequestAddImage}>
+            <ImagePlus className='h-4 w-4 mr-1' />
+            Add Image
+          </Button>
+        </AccordionContent>
+      </AccordionItem>
+    </div>
+  );
+}
+
+// ── Sortable image item ─────────────────────────────────────────────────────
+
+interface SortableImageProps {
+  image: Image;
+  folderName: string;
+  isDragActive: boolean;
+  isBeingDragged: boolean;
+  onRequestEdit: () => void;
+  onRequestDelete: () => void;
+}
+
+function SortableImage({
+  image,
+  folderName,
+  isBeingDragged,
+  onRequestEdit,
+  onRequestDelete
+}: SortableImageProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: `image:${image.id}`,
+    data: { type: 'image', imageId: image.id, folderName }
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.3 : undefined
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className='cursor-move' {...attributes} {...listeners}>
+      <HoverCard openDelay={300}>
+        <HoverCardTrigger asChild>
+          <div style={{ pointerEvents: isBeingDragged ? 'none' : undefined }}>
+            <ImageThumbnail
+              image={image}
+              imgClassName='w-full h-24 object-cover'
+              action={
+                <div className='flex gap-0.5 ml-auto'>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='h-6 w-6'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRequestEdit();
+                    }}>
+                    <Pencil className='h-3 w-3' />
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='icon'
+                    className='h-6 w-6'
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRequestDelete();
+                    }}>
+                    <Trash2 className='h-3 w-3' />
+                  </Button>
+                </div>
+              }
+            />
+          </div>
+        </HoverCardTrigger>
+        {!isBeingDragged && (
+          <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+            <img
+              src={image.url}
+              alt={image.title}
+              className='w-full rounded object-contain max-h-[70vh]'
+            />
+            {image.title && (
+              <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
+            )}
+          </HoverCardContent>
+        )}
+      </HoverCard>
+    </div>
+  );
+}
+
+// ── Main panel ──────────────────────────────────────────────────────────────
 
 export default function ManageImagesPanel() {
   const folders = useImageStore((s) => s.folders);
@@ -24,21 +267,150 @@ export default function ManageImagesPanel() {
   const deleteFolderFn = useImageStore((s) => s.deleteFolder);
   const addImage = useImageStore((s) => s.addImage);
   const deleteImageFn = useImageStore((s) => s.deleteImage);
+  const updateImage = useImageStore((s) => s.updateImage);
+  const moveImage = useImageStore((s) => s.moveImage);
+  const reorderImages = useImageStore((s) => s.reorderImages);
+  const reorderFolders = useImageStore((s) => s.reorderFolders);
 
   const [targetFolder, setTargetFolder] = useState('');
+  const [editTarget, setEditTarget] = useState<Image | null>(null);
   const [subDialog, setSubDialog] = useState<SubDialog>(null);
-  const [openFolders, setOpenFolders] = useState<string[]>([]);
+  const [openFolders, setOpenFolders] = useState<string[]>(() => folders.map((f) => f.folderName));
+  const [search, setSearch] = useState('');
+  const preSearchOpen = useRef<string[] | null>(null);
+
+  // DnD state
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [activeDragType, setActiveDragType] = useState<'folder' | 'image' | null>(null);
+  const [activeImageId, setActiveImageId] = useState<string | null>(null);
+  const [activeDragImage, setActiveDragImage] = useState<Image | null>(null);
+
   const deleteImage = useConfirmDelete<{ folder: string; image: Image }>();
   const deleteFolder = useConfirmDelete<string>();
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const sortedFolders = [...folders].sort((a, b) => a.displayOrder - b.displayOrder);
+  const folderNames = sortedFolders.map((f) => f.folderName);
 
   const openSub = (dialog: SubDialog, folder = '') => {
     setTargetFolder(folder);
     setSubDialog(dialog);
   };
 
-  const closeSub = () => setSubDialog(null);
+  const closeSub = () => {
+    setSubDialog(null);
+    setEditTarget(null);
+  };
 
-  const folderNames = folders.map((f) => f.folderName);
+  const handleSearchChange = (value: string) => {
+    if (!search && value) {
+      // First keystroke — capture current open state
+      preSearchOpen.current = openFolders;
+      // Auto-expand folders with matches
+      const term = value.toLowerCase();
+      const toOpen = sortedFolders
+        .filter((f) =>
+          f.images.some((img) =>
+            img.title
+              ? img.title.toLowerCase().includes(term)
+              : img.url.toLowerCase().includes(term)
+          )
+        )
+        .map((f) => f.folderName);
+      setOpenFolders(toOpen);
+    } else if (search && !value) {
+      // Cleared — restore pre-search state
+      setOpenFolders(preSearchOpen.current ?? []);
+      preSearchOpen.current = null;
+    } else if (value) {
+      // Already searching — update expanded set
+      const term = value.toLowerCase();
+      const toOpen = sortedFolders
+        .filter((f) =>
+          f.images.some((img) =>
+            img.title
+              ? img.title.toLowerCase().includes(term)
+              : img.url.toLowerCase().includes(term)
+          )
+        )
+        .map((f) => f.folderName);
+      setOpenFolders(toOpen);
+    }
+    setSearch(value);
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    document.body.style.cursor = 'grabbing';
+    const { id, data } = event.active;
+    setActiveDragId(String(id));
+    const type = data.current?.type as 'folder' | 'image';
+    setActiveDragType(type);
+    if (type === 'image') {
+      const imgId = data.current?.imageId as string;
+      const folderName = data.current?.folderName as string;
+      setActiveImageId(imgId);
+      const img =
+        folders.find((f) => f.folderName === folderName)?.images.find((i) => i.id === imgId) ??
+        null;
+      setActiveDragImage(img);
+    }
+  };
+
+  const handleDragOver = (_event: DragOverEvent) => {
+    // Nothing needed — drop targets handle their own highlight via useDroppable isOver
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    document.body.style.cursor = '';
+    const { active, over } = event;
+    setActiveDragId(null);
+    setActiveDragType(null);
+    setActiveImageId(null);
+    setActiveDragImage(null);
+
+    if (!over) return;
+
+    const activeType = active.data.current?.type;
+
+    if (activeType === 'folder') {
+      const fromId = String(active.id).replace('folder:', '');
+      const toId = String(over.id).replace('folder:', '');
+      if (fromId === toId) return;
+      const fromIndex = sortedFolders.findIndex((f) => f.folderName === fromId);
+      const toIndex = sortedFolders.findIndex((f) => f.folderName === toId);
+      if (fromIndex !== -1 && toIndex !== -1) reorderFolders(fromIndex, toIndex);
+      return;
+    }
+
+    if (activeType === 'image') {
+      const imageId = active.data.current?.imageId as string;
+      const fromFolder = active.data.current?.folderName as string;
+      const overId = String(over.id);
+
+      // Drop onto a folder header (via droppable zone or sortable zone)
+      if (overId.startsWith('folder-drop:') || overId.startsWith('folder:')) {
+        const toFolder = overId.startsWith('folder-drop:')
+          ? overId.replace('folder-drop:', '')
+          : overId.replace('folder:', '');
+        if (toFolder !== fromFolder) moveImage(fromFolder, toFolder, imageId);
+        return;
+      }
+
+      // Drop onto another image (reorder within same folder)
+      if (overId.startsWith('image:')) {
+        const toImageId = overId.replace('image:', '');
+        const folder = sortedFolders.find((f) => f.folderName === fromFolder);
+        if (!folder) return;
+        const sortedImages = [...folder.images].sort((a, b) => a.displayOrder - b.displayOrder);
+        const fromIndex = sortedImages.findIndex((i) => i.id === imageId);
+        const toIndex = sortedImages.findIndex((i) => i.id === toImageId);
+        if (fromIndex !== -1 && toIndex !== -1 && fromIndex !== toIndex) {
+          reorderImages(fromFolder, fromIndex, toIndex);
+        }
+      }
+    }
+  };
 
   return (
     <>
@@ -69,6 +441,24 @@ export default function ManageImagesPanel() {
         onSave={(url, title) => addImage(targetFolder, url, title || undefined)}
       />
 
+      <AddImageDialog
+        key={editTarget?.id ?? ''}
+        open={subDialog === 'editImage'}
+        onClose={closeSub}
+        targetFolder={targetFolder}
+        initialValues={
+          editTarget ? { url: editTarget.url, title: editTarget.title ?? '' } : undefined
+        }
+        onSave={(url, title) => {
+          if (!editTarget) return false;
+          const folder = folders.find((f) => f.folderName === targetFolder);
+          const isDupe = folder?.images.some((img) => img.url === url && img.id !== editTarget.id);
+          if (isDupe) return false;
+          updateImage(targetFolder, editTarget.id, { url, title: title || undefined });
+          return true;
+        }}
+      />
+
       <RenameFolderDialog
         open={subDialog === 'rename'}
         onClose={closeSub}
@@ -89,81 +479,73 @@ export default function ManageImagesPanel() {
 
       <div className='flex flex-col flex-1 min-h-0'>
         <div className='overflow-auto flex-1 p-4 space-y-4'>
-          {folders.length === 0 ? (
+          <div className='relative'>
+            <Input
+              placeholder='Search images…'
+              value={search}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              className='pr-8'
+            />
+            {search && (
+              <button
+                onClick={() => handleSearchChange('')}
+                className='absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground'>
+                <X className='h-4 w-4' />
+              </button>
+            )}
+          </div>
+
+          {sortedFolders.length === 0 ? (
             <p className='text-sm text-muted-foreground'>No folders yet.</p>
           ) : (
-            <Accordion
-              type='multiple'
-              value={openFolders}
-              onValueChange={setOpenFolders}
-              className='space-y-1'>
-              {folders.map((folder) => (
-                <AccordionItem
-                  key={folder.folderName}
-                  value={folder.folderName}
-                  className='border rounded'>
-                  <div className='flex items-center px-3'>
-                    <AccordionTrigger className='flex-1 hover:no-underline'>
-                      <span className='flex items-center gap-1.5 text-sm font-medium'>
-                        {folder.folderName}
-                        <span className='text-xs text-muted-foreground font-normal leading-none'>
-                          ({folder.images.length})
-                        </span>
-                      </span>
-                    </AccordionTrigger>
-                    <div className='flex gap-0.5 shrink-0'>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        className='h-7 w-7'
-                        onClick={() => openSub('rename', folder.folderName)}>
-                        <Pencil className='h-3.5 w-3.5' />
-                      </Button>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        className='h-7 w-7 text-destructive hover:text-destructive'
-                        onClick={() => deleteFolder.requestDelete(folder.folderName)}>
-                        <Trash2 className='h-3.5 w-3.5' />
-                      </Button>
-                    </div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={collisionDetection}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragEnd={handleDragEnd}>
+              <SortableContext
+                items={sortedFolders.map((f) => `folder:${f.folderName}`)}
+                strategy={verticalListSortingStrategy}>
+                <Accordion
+                  type='multiple'
+                  value={openFolders}
+                  onValueChange={setOpenFolders}
+                  className='space-y-1'>
+                  {sortedFolders.map((folder) => (
+                    <SortableFolder
+                      key={folder.folderName}
+                      folder={folder}
+                      isDragActive={!!activeDragId}
+                      activeDragType={activeDragType}
+                      activeImageId={activeImageId}
+                      search={search}
+                      onRequestRename={() => openSub('rename', folder.folderName)}
+                      onRequestDelete={() => deleteFolder.requestDelete(folder.folderName)}
+                      onRequestAddImage={() => openSub('addImage', folder.folderName)}
+                      onRequestEditImage={(img) => {
+                        setEditTarget(img);
+                        openSub('editImage', folder.folderName);
+                      }}
+                      onRequestDeleteImage={(img) =>
+                        deleteImage.requestDelete({ folder: folder.folderName, image: img })
+                      }
+                    />
+                  ))}
+                </Accordion>
+              </SortableContext>
+              <DragOverlay>
+                {activeDragImage && (
+                  <div className='w-32 opacity-90 shadow-lg rounded overflow-hidden'>
+                    <ImageThumbnail
+                      image={activeDragImage}
+                      imgClassName='w-full h-24 object-cover'
+                      action={null}
+                    />
                   </div>
-                  <AccordionContent className='px-3 pb-3 space-y-2'>
-                    {folder.images.length > 0 ? (
-                      <div className='grid grid-cols-4 gap-2'>
-                        {folder.images.map((image) => (
-                          <ImageThumbnail
-                            key={image.id}
-                            image={image}
-                            imgClassName='w-full h-40 object-cover'
-                            action={
-                              <Button
-                                variant='ghost'
-                                size='icon'
-                                className='h-6 w-6 ml-auto'
-                                onClick={() =>
-                                  deleteImage.requestDelete({ folder: folder.folderName, image })
-                                }>
-                                <Trash2 className='h-3.5 w-3.5' />
-                              </Button>
-                            }
-                          />
-                        ))}
-                      </div>
-                    ) : (
-                      <p className='text-sm text-muted-foreground py-1'>No images yet.</p>
-                    )}
-                    <Button
-                      variant='outline'
-                      size='sm'
-                      onClick={() => openSub('addImage', folder.folderName)}>
-                      <ImagePlus className='h-4 w-4 mr-1' />
-                      Add Image
-                    </Button>
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
+                )}
+              </DragOverlay>
+            </DndContext>
           )}
         </div>
 
@@ -172,16 +554,18 @@ export default function ManageImagesPanel() {
             <FolderPlus className='h-4 w-4 mr-1' />
             New Folder
           </Button>
-          {folders.length > 0 && (
+          {sortedFolders.length > 0 && (
             <Button
               variant='ghost'
               size='sm'
               onClick={() =>
                 setOpenFolders(
-                  openFolders.length === folders.length ? [] : folders.map((f) => f.folderName)
+                  openFolders.length === sortedFolders.length
+                    ? []
+                    : sortedFolders.map((f) => f.folderName)
                 )
               }>
-              {openFolders.length === folders.length ? 'Collapse All' : 'Expand All'}
+              {openFolders.length === sortedFolders.length ? 'Collapse All' : 'Expand All'}
             </Button>
           )}
         </div>

--- a/src/components/images/manage-images-panel.tsx
+++ b/src/components/images/manage-images-panel.tsx
@@ -2,7 +2,6 @@ import { useState, useRef } from 'react';
 import {
   DndContext,
   DragEndEvent,
-  DragOverEvent,
   DragStartEvent,
   PointerSensor,
   useSensor,
@@ -63,7 +62,6 @@ interface SortableFolderProps {
 
 function SortableFolder({
   folder,
-  isDragActive,
   activeDragType,
   activeImageId,
   search,
@@ -154,7 +152,6 @@ function SortableFolder({
                     key={image.id}
                     image={image}
                     folderName={folder.folderName}
-                    isDragActive={isDragActive}
                     isBeingDragged={activeImageId === image.id}
                     onRequestEdit={() => onRequestEditImage(image)}
                     onRequestDelete={() => onRequestDeleteImage(image)}
@@ -182,7 +179,6 @@ function SortableFolder({
 interface SortableImageProps {
   image: Image;
   folderName: string;
-  isDragActive: boolean;
   isBeingDragged: boolean;
   onRequestEdit: () => void;
   onRequestDelete: () => void;
@@ -357,10 +353,6 @@ export default function ManageImagesPanel() {
     }
   };
 
-  const handleDragOver = (_event: DragOverEvent) => {
-    // Nothing needed — drop targets handle their own highlight via useDroppable isOver
-  };
-
   const handleDragEnd = (event: DragEndEvent) => {
     document.body.style.cursor = '';
     const { active, over } = event;
@@ -502,7 +494,6 @@ export default function ManageImagesPanel() {
               sensors={sensors}
               collisionDetection={collisionDetection}
               onDragStart={handleDragStart}
-              onDragOver={handleDragOver}
               onDragEnd={handleDragEnd}>
               <SortableContext
                 items={sortedFolders.map((f) => `folder:${f.folderName}`)}

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,0 +1,30 @@
+import { HoverCard as HoverCardPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const HoverCard = HoverCardPrimitive.Root;
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+function HoverCardContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 rounded-md border p-3 shadow-md outline-none',
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export { HoverCard, HoverCardContent, HoverCardTrigger };

--- a/src/store/__tests__/imageStore.test.ts
+++ b/src/store/__tests__/imageStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { useImageStore } from '../imageStore';
 
 beforeEach(() => {
-  useImageStore.setState({ folders: [{ folderName: 'Test', images: [] }] });
+  useImageStore.setState({ folders: [{ folderName: 'Test', images: [], displayOrder: 0 }] });
 });
 
 describe('imageStore.addImage', () => {

--- a/src/store/__tests__/migrations.test.ts
+++ b/src/store/__tests__/migrations.test.ts
@@ -109,6 +109,23 @@ const v1Images = {
   ]
 };
 
+const v2Images = Object.freeze({
+  folders: [
+    {
+      folderName: 'Goblins',
+      displayOrder: 0,
+      images: [
+        {
+          id: 'a1b2c3d4-0000-0000-0000-000000000001',
+          url: 'https://example.com/goblin.png',
+          title: 'Goblin',
+          displayOrder: 0
+        }
+      ]
+    }
+  ]
+});
+
 const v0Notes = { notes: 'Session notes here.' };
 
 const v0Combat = { actors: [], selectedIndex: 0, round: 1 };
@@ -199,8 +216,14 @@ describe('campaignStore migrations', () => {
 });
 
 describe('imageStore migrations', () => {
-  it('v1 state is preserved', () => {
-    expect(migrateImageStore(structuredClone(v1Images), 1), CONTRACT_BROKEN).toEqual(v1Images);
+  it('v2 state is preserved', () => {
+    expect(migrateImageStore(structuredClone(v2Images), 2), CONTRACT_BROKEN).toEqual(v2Images);
+  });
+
+  it('v1 → v2: displayOrder stamped from array index', () => {
+    const result = migrateImageStore(structuredClone(v1Images), 1) as typeof v2Images;
+    expect(result.folders[0].displayOrder, CONTRACT_BROKEN).toBe(0);
+    expect(result.folders[0].images[0].displayOrder, CONTRACT_BROKEN).toBe(0);
   });
 
   it('v0 → v1: images get a stable id', () => {

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -5,11 +5,13 @@ export interface Image {
   id: string;
   url: string;
   title?: string;
+  displayOrder: number;
 }
 
 export interface ImageFolder {
   folderName: string;
   images: Image[];
+  displayOrder: number;
 }
 
 interface ImageStore {
@@ -19,15 +21,21 @@ interface ImageStore {
   deleteFolder: (folderName: string) => void;
   addImage: (folderName: string, url: string, title?: string) => boolean;
   deleteImage: (folderName: string, image: Image) => void;
+  updateImage: (folderName: string, imageId: string, updates: Pick<Image, 'url' | 'title'>) => void;
+  moveImage: (fromFolder: string, toFolder: string, imageId: string) => void;
+  reorderImages: (folderName: string, fromIndex: number, toIndex: number) => void;
+  reorderFolders: (fromIndex: number, toIndex: number) => void;
 }
 
 const DEFAULT_FOLDERS: ImageFolder[] = [
   {
     folderName: 'Goblins',
+    displayOrder: 0,
     images: [
       {
         id: crypto.randomUUID(),
-        url: 'https://legendary-digital-network-assets.s3.amazonaws.com/geekandsundry/wp-content/uploads/2016/11/goblin-step1.png'
+        url: 'https://legendary-digital-network-assets.s3.amazonaws.com/geekandsundry/wp-content/uploads/2016/11/goblin-step1.png',
+        displayOrder: 0
       }
     ]
   }
@@ -49,7 +57,32 @@ export function migrateImageStore(state: unknown, version: number): { folders: I
       }))
     };
   }
+  if (version < 2) {
+    s = {
+      ...s,
+      folders: s.folders.map((f, fi) => ({
+        ...f,
+        displayOrder: fi,
+        images: f.images.map((img, ii) => ({ ...img, displayOrder: ii }))
+      }))
+    };
+  }
   return s;
+}
+
+function stampDisplayOrder(arr: ImageFolder[]): ImageFolder[] {
+  return arr.map((f, fi) => ({
+    ...f,
+    displayOrder: fi,
+    images: f.images.map((img, ii) => ({ ...img, displayOrder: ii }))
+  }));
+}
+
+function reorder<T>(arr: T[], from: number, to: number): T[] {
+  const result = [...arr];
+  const [item] = result.splice(from, 1);
+  result.splice(to, 0, item);
+  return result;
 }
 
 export const useImageStore = create<ImageStore>()(
@@ -65,7 +98,9 @@ export const useImageStore = create<ImageStore>()(
           const suffix = numNewFolders > 0 ? ` ${numNewFolders + 1}` : '';
           folderName = `New Folder${suffix}`;
         }
-        set({ folders: [...folders, { folderName, images: [] }] });
+        set({
+          folders: [...folders, { folderName, images: [], displayOrder: folders.length }]
+        });
       },
 
       renameFolder: (oldName, newName) => {
@@ -77,7 +112,8 @@ export const useImageStore = create<ImageStore>()(
       },
 
       deleteFolder: (folderName) => {
-        set({ folders: get().folders.filter((f) => f.folderName !== folderName) });
+        const remaining = get().folders.filter((f) => f.folderName !== folderName);
+        set({ folders: remaining.map((f, i) => ({ ...f, displayOrder: i })) });
       },
 
       addImage: (folderName, url, title) => {
@@ -87,7 +123,13 @@ export const useImageStore = create<ImageStore>()(
         set({
           folders: get().folders.map((f) =>
             f.folderName === folderName
-              ? { ...f, images: [...f.images, { id: crypto.randomUUID(), url, title }] }
+              ? {
+                  ...f,
+                  images: [
+                    ...f.images,
+                    { id: crypto.randomUUID(), url, title, displayOrder: f.images.length }
+                  ]
+                }
               : f
           )
         });
@@ -96,17 +138,66 @@ export const useImageStore = create<ImageStore>()(
 
       deleteImage: (folderName, image) => {
         set({
+          folders: get().folders.map((f) => {
+            if (f.folderName !== folderName) return f;
+            const remaining = f.images.filter((i) => i.id !== image.id);
+            return { ...f, images: remaining.map((img, i) => ({ ...img, displayOrder: i })) };
+          })
+        });
+      },
+
+      updateImage: (folderName, imageId, updates) => {
+        set({
           folders: get().folders.map((f) =>
-            f.folderName === folderName
-              ? { ...f, images: f.images.filter((i) => i.id !== image.id) }
-              : f
+            f.folderName !== folderName
+              ? f
+              : {
+                  ...f,
+                  images: f.images.map((img) => (img.id === imageId ? { ...img, ...updates } : img))
+                }
           )
         });
+      },
+
+      moveImage: (fromFolder, toFolder, imageId) => {
+        if (fromFolder === toFolder) return;
+        const folders = get().folders;
+        const srcFolder = folders.find((f) => f.folderName === fromFolder);
+        const image = srcFolder?.images.find((i) => i.id === imageId);
+        if (!image) return;
+        set({
+          folders: stampDisplayOrder(
+            folders.map((f) => {
+              if (f.folderName === fromFolder) {
+                return { ...f, images: f.images.filter((i) => i.id !== imageId) };
+              }
+              if (f.folderName === toFolder) {
+                return { ...f, images: [...f.images, image] };
+              }
+              return f;
+            })
+          )
+        });
+      },
+
+      reorderImages: (folderName, fromIndex, toIndex) => {
+        set({
+          folders: get().folders.map((f) => {
+            if (f.folderName !== folderName) return f;
+            const reordered = reorder(f.images, fromIndex, toIndex);
+            return { ...f, images: reordered.map((img, i) => ({ ...img, displayOrder: i })) };
+          })
+        });
+      },
+
+      reorderFolders: (fromIndex, toIndex) => {
+        const reordered = reorder(get().folders, fromIndex, toIndex);
+        set({ folders: reordered.map((f, i) => ({ ...f, displayOrder: i })) });
       }
     }),
     {
       name: STORE_KEY,
-      version: 1,
+      version: 2,
       migrate: migrateImageStore
     }
   )


### PR DESCRIPTION
## Summary

Implements the full images enhancement spec: drag-and-drop ordering and cross-folder moves in prep mode, search in both prep and DM view, hover card previews, and image editing.

## What changed

- **`imageStore.ts`** — v1→v2 migration stamps `displayOrder` on folders and images; new actions `updateImage`, `moveImage`, `reorderImages`, `reorderFolders`
- **`manage-images-panel.tsx`** — full rewrite with dnd-kit: folder reorder via grip handle, image reorder within folders, drag-to-header to move images between folders; search with M-of-N counts and open-state restore; pencil edit button with dupe-safe dialog; HoverCard preview (suppressed during drag); grabbing cursor + drop target highlights during drag
- **`images.tsx` / `folder-list.tsx`** — search input above folder list; active search replaces accordion with flat cross-folder grid showing folder name per tile; HoverCard on all thumbnails
- **`imageGrid.tsx`** — HoverCard previews, 6-col grid, h-24 tiles
- **`add-image-dialog.tsx`** — `initialValues` prop for edit mode; Enter saves from title field; dupe check applies in edit mode (excludes self)
- **`hover-card.tsx`** — new shadcn-style HoverCard UI component
- **`migrations.test.ts`** — v2 snapshot + two new migration tests

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] Tested in the browser (dev server)
- [x] No regressions in related features