### PR TITLE
feat: combat initiative overhaul — load/start/end flow, ad-hoc combatants, initiative editing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ['**']
+    branches: ['main']
   pull_request:
     branches: ['**']
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ The DM and player views communicate via **PartyKit WebSockets** (`src/lib/sync.t
 | `imageStore`     | `dm-screen/images`                  | ✅                   | Folders + image URLs; enforces unique URLs per folder                         |
 | `notesStore`     | `dm-screen/notes`                   | ✅                   | Single freeform notes string                                                  |
 | `encounterStore` | `dm-screen/encounters`              | ✅                   | Stat blocks + named encounter templates                                       |
-| `combatStore`    | `dm-screen/combat`                  | ❌ ephemeral         | Active initiative state; survives page refresh, not export                    |
+| `combatStore`    | `dm-screen/combat`                  | ❌ ephemeral         | Active initiative state; `started` flag separates loaded vs running; survives page refresh, not export |
 | `dmSessionStore` | `dm-screen/dm-session`              | ❌ ephemeral         | `wantLive` flag (persist intent to reconnect after refresh)                   |
 | `playerStore`    | `dm-screen/player`                  | ❌ per-browser       | Player's display name; set once on the player view                            |
 | `uiStore`        | `dm-screen/ui` (lastSentImage only) | ❌ ephemeral         | `lastSentImage` persisted via `partialize`; `initiativeActive` is memory-only |
@@ -60,11 +60,11 @@ Each store that participates in export/import exports `STORE_KEY` and a `migrate
 
 - `src/lib/exportImport.ts` — serializes/restores the 5 backed-up stores as JSON; deliberately excludes the 4 ephemeral stores (see table above)
 - `src/lib/useConfirmDelete.ts` — shared hook for the pending-delete pattern used across all Manage\* panels
-- `src/lib/utils.ts` — `cn()` (clsx + tailwind-merge), `formatBonus()`, `randomNpcName()`
+- `src/lib/utils.ts` — `cn()` (clsx + tailwind-merge), `formatBonus()`, `randomNpcName()`, `rollInitiative(dexMod?)`, `dexModifier(dex)`
 
 ## Key Flows
 
-**Initiative**: `InitiativeTracker` → open `InitiativeSetupDialog` (seeds players from the active campaign's characters + lets DM add NPCs, enter rolls, optionally load an encounter template) → `startInitiative()` sorts by roll, persists to `combatStore`, broadcasts via sync layer on every change.
+**Initiative**: Three-phase flow — **Load** → **Start** → **End**. `InitiativeTracker` → open `InitiativeSetupDialog` (seeds players from active campaign, lets DM add NPCs with auto-rolled initiative, optionally apply an encounter template) → "Load" sorts actors into `combatStore` with `started: false`. In loaded state the DM can edit initiatives inline, add/delete actors, and wait for PC rolls (zero-init cells are amber). "Start" re-sorts and sets `started: true`, which begins turn tracking and starts syncing to players. Mid-combat, "+" opens `AddCombatantDialog` (searchable stat-block picker, auto-rolled init); new combatants drop to the end of the order. NPC HP → 0 marks them inactive; HP > 0 re-activates.
 
 **Images**: `ImageSender` (paste a URL, send ad-hoc) or `ImageGrid` (saved folder images) → `onSendImage` → `sendMessage({ cmd: 'image', payload })` → player view renders it full-screen.
 

--- a/src/components/characters/initiative/__tests__/addCombatantDialog.test.tsx
+++ b/src/components/characters/initiative/__tests__/addCombatantDialog.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AddCombatantDialog from '../addCombatantDialog';
+import { useEncounterStore } from '../../../../store/encounterStore';
+import type { Actor } from '../../../../lib/sync';
+
+const STAT_BLOCKS = [
+  { id: 'sb1', name: 'Goblin', hp: 7, dex: 14 },
+  { id: 'sb2', name: 'Troll', hp: 84, dex: 8 }
+];
+
+beforeEach(() => {
+  useEncounterStore.setState({ statBlocks: STAT_BLOCKS, templates: [] });
+});
+
+describe('AddCombatantDialog', () => {
+  it('Add button is disabled when name is empty', () => {
+    render(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={vi.fn()} />);
+    const nameInput = screen.getByRole('textbox');
+    fireEvent.change(nameInput, { target: { value: '' } });
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+  });
+
+  it('calls onAdd with a well-formed NPC actor', () => {
+    const onAdd = vi.fn();
+    render(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={onAdd} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Test NPC' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(onAdd).toHaveBeenCalledOnce();
+    const actors = onAdd.mock.calls[0][0] as Actor[];
+    expect(actors).toHaveLength(1);
+    const actor = actors[0];
+    expect(actor.name).toBe('Test NPC');
+    expect(actor.kind).toBe('npc');
+    expect(actor.active).toBe(true);
+    expect(actor.conditions).toEqual([]);
+    expect(typeof actor.id).toBe('string');
+    expect(typeof actor.init).toBe('number');
+  });
+
+  it('picking a stat block sets name, max HP, and statBlockId', () => {
+    const onAdd = vi.fn();
+    render(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={onAdd} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /pick stat block/i }));
+    fireEvent.click(screen.getByText('Goblin'));
+
+    expect(screen.getByRole('textbox')).toHaveValue('Goblin');
+    const spinbuttons = screen.getAllByRole('spinbutton');
+    expect(Number(spinbuttons[1].getAttribute('value'))).toBe(7); // Max HP
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const actors = onAdd.mock.calls[0][0] as Actor[];
+    expect(actors[0].statBlockId).toBe('sb1');
+    expect(actors[0].maxHp).toBe(7);
+  });
+
+  it('no statBlockId on actor when no stat block selected', () => {
+    const onAdd = vi.fn();
+    render(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={onAdd} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Minion' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    const actors = onAdd.mock.calls[0][0] as Actor[];
+    expect(actors[0].statBlockId).toBeUndefined();
+  });
+
+  it('draft resets after adding so the dialog is fresh next open', () => {
+    const onAdd = vi.fn();
+    const { rerender } = render(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={onAdd} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'One-shot NPC' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    // Reopen
+    rerender(<AddCombatantDialog isOpen onClose={vi.fn()} onAdd={onAdd} />);
+    expect(screen.getByRole('textbox')).not.toHaveValue('One-shot NPC');
+  });
+});

--- a/src/components/characters/initiative/__tests__/initiativeSetupDialog.test.tsx
+++ b/src/components/characters/initiative/__tests__/initiativeSetupDialog.test.tsx
@@ -55,7 +55,7 @@ describe('InitiativeSetupDialog', () => {
     fireEvent.change(initInputs[0], { target: { value: '10' } }); // Gandalf
     fireEvent.change(initInputs[1], { target: { value: '15' } }); // Bilbo
 
-    fireEvent.click(screen.getByText('Start!'));
+    fireEvent.click(screen.getByText('Load'));
 
     expect(onStart).toHaveBeenCalledOnce();
     const sorted = onStart.mock.calls[0][0] as Actor[];
@@ -69,7 +69,7 @@ describe('InitiativeSetupDialog', () => {
     // Select the encounter template
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: 't1' } });
-    fireEvent.click(screen.getByRole('button', { name: /load/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
 
     // Template NPCs should now appear as editable name inputs
     expect(screen.getByDisplayValue('Goblin 1')).toBeInTheDocument();
@@ -82,10 +82,10 @@ describe('InitiativeSetupDialog', () => {
     // Load once
     const select = screen.getByRole('combobox');
     fireEvent.change(select, { target: { value: 't1' } });
-    fireEvent.click(screen.getByRole('button', { name: /load/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
 
     // Load again — should not double-up NPCs
-    fireEvent.click(screen.getByRole('button', { name: /load/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
     expect(screen.getAllByDisplayValue('Goblin 1')).toHaveLength(1);
 
     // Players still present (rendered as text spans, not inputs)

--- a/src/components/characters/initiative/addCombatantDialog.tsx
+++ b/src/components/characters/initiative/addCombatantDialog.tsx
@@ -12,8 +12,7 @@ import { Switch } from '@/components/ui/switch';
 import { ChevronsUpDown, Check } from 'lucide-react';
 import { Actor } from '../../../lib/sync';
 import { useEncounterStore } from '../../../store/encounterStore';
-import { randomNpcName, rollInitiative, dexModifier } from '@/lib/utils';
-import { cn } from '@/lib/utils';
+import { cn, randomNpcName, rollInitiative, dexModifier } from '@/lib/utils';
 
 interface Props {
   isOpen: boolean;
@@ -71,13 +70,14 @@ export default function AddCombatantDialog({ isOpen, onClose, onAdd }: Props) {
         ...(draft.statBlockId ? { statBlockId: draft.statBlockId } : {})
       }
     ]);
-    setDraft(freshDraft());
+    setDraft(freshDraft);
     onClose();
   };
 
   const handleClose = () => {
-    setDraft(freshDraft());
+    setDraft(freshDraft);
     setSearch('');
+    setPickerOpen(false);
     onClose();
   };
 
@@ -104,49 +104,54 @@ export default function AddCombatantDialog({ isOpen, onClose, onAdd }: Props) {
                   <ChevronsUpDown className='h-3.5 w-3.5 shrink-0 opacity-50 ml-1' />
                 </Button>
                 {pickerOpen && (
-                  <div className='absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md'>
-                    <div className='p-2 border-b'>
-                      <Input
-                        placeholder='Search…'
-                        value={search}
-                        onChange={(e) => setSearch(e.target.value)}
-                        className='h-7 text-sm'
-                        autoFocus
-                      />
-                    </div>
-                    <div className='max-h-48 overflow-y-auto'>
-                      {filtered.length === 0 ? (
-                        <p className='py-3 text-center text-xs text-muted-foreground'>No results</p>
-                      ) : (
-                        filtered.map((sb) => (
-                          <button
-                            key={sb.id}
-                            className={cn(
-                              'flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent cursor-pointer text-left',
-                              draft.statBlockId === sb.id && 'bg-accent'
-                            )}
-                            onClick={() => pickStatBlock(sb.id)}>
-                            <Check
+                  <>
+                    <div className='fixed inset-0 z-9' onClick={() => setPickerOpen(false)} />
+                    <div className='absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md'>
+                      <div className='p-2 border-b'>
+                        <Input
+                          placeholder='Search…'
+                          value={search}
+                          onChange={(e) => setSearch(e.target.value)}
+                          className='h-7 text-sm'
+                          autoFocus
+                        />
+                      </div>
+                      <div className='max-h-48 overflow-y-auto'>
+                        {filtered.length === 0 ? (
+                          <p className='py-3 text-center text-xs text-muted-foreground'>
+                            No results
+                          </p>
+                        ) : (
+                          filtered.map((sb) => (
+                            <button
+                              key={sb.id}
                               className={cn(
-                                'h-3.5 w-3.5 shrink-0',
-                                draft.statBlockId === sb.id ? 'opacity-100' : 'opacity-0'
+                                'flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent cursor-pointer text-left',
+                                draft.statBlockId === sb.id && 'bg-accent'
                               )}
-                            />
-                            {sb.name}
+                              onClick={() => pickStatBlock(sb.id)}>
+                              <Check
+                                className={cn(
+                                  'h-3.5 w-3.5 shrink-0',
+                                  draft.statBlockId === sb.id ? 'opacity-100' : 'opacity-0'
+                                )}
+                              />
+                              {sb.name}
+                            </button>
+                          ))
+                        )}
+                      </div>
+                      {selectedBlock && (
+                        <div className='border-t p-2'>
+                          <button
+                            className='w-full text-xs text-muted-foreground hover:text-foreground text-left px-1'
+                            onClick={clearStatBlock}>
+                            Clear selection
                           </button>
-                        ))
+                        </div>
                       )}
                     </div>
-                    {selectedBlock && (
-                      <div className='border-t p-2'>
-                        <button
-                          className='w-full text-xs text-muted-foreground hover:text-foreground text-left px-1'
-                          onClick={clearStatBlock}>
-                          Clear selection
-                        </button>
-                      </div>
-                    )}
-                  </div>
+                  </>
                 )}
               </div>
             </div>

--- a/src/components/characters/initiative/addCombatantDialog.tsx
+++ b/src/components/characters/initiative/addCombatantDialog.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { ChevronsUpDown, Check } from 'lucide-react';
+import { Actor } from '../../../lib/sync';
+import { useEncounterStore } from '../../../store/encounterStore';
+import { randomNpcName, rollInitiative, dexModifier } from '@/lib/utils';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  onAdd: (actors: Actor[]) => void;
+}
+
+function freshDraft() {
+  return {
+    name: randomNpcName(),
+    init: rollInitiative(),
+    maxHp: 10,
+    hp: 10,
+    visible: true,
+    statBlockId: undefined as string | undefined
+  };
+}
+
+export default function AddCombatantDialog({ isOpen, onClose, onAdd }: Props) {
+  const [draft, setDraft] = useState(freshDraft);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const statBlocks = useEncounterStore((s) => s.statBlocks);
+
+  const filtered = statBlocks.filter((sb) => sb.name.toLowerCase().includes(search.toLowerCase()));
+
+  const selectedBlock = statBlocks.find((sb) => sb.id === draft.statBlockId);
+
+  const pickStatBlock = (id: string) => {
+    const sb = statBlocks.find((s) => s.id === id);
+    if (!sb) return;
+    const init = rollInitiative(sb.dex !== undefined ? dexModifier(sb.dex) : 0);
+    setDraft((d) => ({ ...d, name: sb.name, init, maxHp: sb.hp, hp: sb.hp, statBlockId: sb.id }));
+    setSearch('');
+    setPickerOpen(false);
+  };
+
+  const clearStatBlock = () => {
+    setDraft((d) => ({ ...d, statBlockId: undefined }));
+    setPickerOpen(false);
+  };
+
+  const handleAdd = () => {
+    onAdd([
+      {
+        id: crypto.randomUUID(),
+        kind: 'npc',
+        active: true,
+        conditions: [],
+        name: draft.name,
+        init: draft.init,
+        maxHp: draft.maxHp,
+        hp: draft.hp,
+        visible: draft.visible,
+        ...(draft.statBlockId ? { statBlockId: draft.statBlockId } : {})
+      }
+    ]);
+    setDraft(freshDraft());
+    onClose();
+  };
+
+  const handleClose = () => {
+    setDraft(freshDraft());
+    setSearch('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className='max-w-xs'>
+        <DialogHeader>
+          <DialogTitle>Add Combatant</DialogTitle>
+        </DialogHeader>
+
+        <div className='space-y-3'>
+          {statBlocks.length > 0 && (
+            <div className='grid grid-cols-[3.5rem_1fr] gap-2 items-start'>
+              <label className='text-xs text-muted-foreground mt-2'>NPC</label>
+              <div className='relative'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  className='h-8 w-full justify-between font-normal text-sm'
+                  onClick={() => setPickerOpen((o) => !o)}>
+                  <span className='truncate'>
+                    {selectedBlock ? selectedBlock.name : 'Pick stat block…'}
+                  </span>
+                  <ChevronsUpDown className='h-3.5 w-3.5 shrink-0 opacity-50 ml-1' />
+                </Button>
+                {pickerOpen && (
+                  <div className='absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md'>
+                    <div className='p-2 border-b'>
+                      <Input
+                        placeholder='Search…'
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                        className='h-7 text-sm'
+                        autoFocus
+                      />
+                    </div>
+                    <div className='max-h-48 overflow-y-auto'>
+                      {filtered.length === 0 ? (
+                        <p className='py-3 text-center text-xs text-muted-foreground'>No results</p>
+                      ) : (
+                        filtered.map((sb) => (
+                          <button
+                            key={sb.id}
+                            className={cn(
+                              'flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent cursor-pointer text-left',
+                              draft.statBlockId === sb.id && 'bg-accent'
+                            )}
+                            onClick={() => pickStatBlock(sb.id)}>
+                            <Check
+                              className={cn(
+                                'h-3.5 w-3.5 shrink-0',
+                                draft.statBlockId === sb.id ? 'opacity-100' : 'opacity-0'
+                              )}
+                            />
+                            {sb.name}
+                          </button>
+                        ))
+                      )}
+                    </div>
+                    {selectedBlock && (
+                      <div className='border-t p-2'>
+                        <button
+                          className='w-full text-xs text-muted-foreground hover:text-foreground text-left px-1'
+                          onClick={clearStatBlock}>
+                          Clear selection
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          <div className='grid grid-cols-[3.5rem_1fr] gap-2 items-center'>
+            <label className='text-xs text-muted-foreground'>Init</label>
+            <Input
+              type='number'
+              value={draft.init}
+              onChange={(e) => setDraft((d) => ({ ...d, init: Number(e.target.value) }))}
+              onFocus={(e) => e.target.select()}
+              className='h-8 text-sm px-2'
+              autoFocus={statBlocks.length === 0}
+            />
+          </div>
+          <div className='grid grid-cols-[3.5rem_1fr] gap-2 items-center'>
+            <label className='text-xs text-muted-foreground'>Name</label>
+            <Input
+              value={draft.name}
+              onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+              className='h-8 text-sm'
+            />
+          </div>
+          <div className='grid grid-cols-[3.5rem_1fr] gap-2 items-center'>
+            <label className='text-xs text-muted-foreground'>Max HP</label>
+            <Input
+              type='number'
+              value={draft.maxHp}
+              onChange={(e) => {
+                const v = Math.max(1, Number(e.target.value));
+                setDraft((d) => ({ ...d, maxHp: v, hp: v }));
+              }}
+              onFocus={(e) => e.target.select()}
+              className='h-8 text-sm px-2'
+            />
+          </div>
+          <div className='grid grid-cols-[3.5rem_1fr] gap-2 items-center'>
+            <label className='text-xs text-muted-foreground'>Visible</label>
+            <Switch
+              checked={draft.visible}
+              onCheckedChange={(checked) => setDraft((d) => ({ ...d, visible: checked }))}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant='outline' onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleAdd} disabled={!draft.name.trim()}>
+            Add
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/characters/initiative/initiativeSetupDialog.tsx
+++ b/src/components/characters/initiative/initiativeSetupDialog.tsx
@@ -17,7 +17,7 @@ import { useConfirmDelete } from '@/lib/useConfirmDelete';
 import { useCharacterStore } from '../../../store/characterStore';
 import { useEncounterStore } from '../../../store/encounterStore';
 import { useCampaignStore } from '../../../store/campaignStore';
-import { randomNpcName } from '@/lib/utils';
+import { randomNpcName, rollInitiative, dexModifier } from '@/lib/utils';
 
 function newPlayerActors(characters: { name: string }[]): Actor[] {
   return characters.map((c) => ({
@@ -76,7 +76,7 @@ export default function InitiativeSetupDialog({
         id: crypto.randomUUID(),
         kind: 'npc',
         name: randomNpcName(),
-        init: 0,
+        init: rollInitiative(),
         maxHp: 10,
         hp: 10,
         visible: true,
@@ -97,7 +97,7 @@ export default function InitiativeSetupDialog({
         id: crypto.randomUUID(),
         kind: 'npc' as const,
         name: entry.instanceName,
-        init: 0,
+        init: rollInitiative(sb?.dex !== undefined ? dexModifier(sb.dex) : 0),
         maxHp,
         hp: maxHp,
         statBlockId: entry.statBlockId,
@@ -144,6 +144,7 @@ export default function InitiativeSetupDialog({
                     type='number'
                     value={actor.init}
                     onChange={(e) => updateActor(actor.id, { init: Number(e.target.value) })}
+                    onFocus={(e) => e.target.select()}
                     className='h-8 text-sm px-2'
                   />
                   <span className='text-sm px-2 py-1'>{actor.name}</span>
@@ -180,7 +181,7 @@ export default function InitiativeSetupDialog({
                     size='sm'
                     onClick={loadEncounter}
                     disabled={!loadEncounterId}>
-                    Load
+                    Apply
                   </Button>
                 </div>
               )}
@@ -201,6 +202,7 @@ export default function InitiativeSetupDialog({
                     type='number'
                     value={actor.init}
                     onChange={(e) => updateActor(actor.id, { init: Number(e.target.value) })}
+                    onFocus={(e) => e.target.select()}
                     className='h-8 text-sm px-2'
                   />
                   <Input
@@ -215,6 +217,7 @@ export default function InitiativeSetupDialog({
                       const maxHp = Math.max(1, Number(e.target.value));
                       updateActor(actor.id, { maxHp, hp: maxHp });
                     }}
+                    onFocus={(e) => e.target.select()}
                     className='h-8 text-sm px-2'
                   />
                   <div className='flex justify-center'>
@@ -243,7 +246,7 @@ export default function InitiativeSetupDialog({
             <Button variant='outline' onClick={handleReset}>
               Reset
             </Button>
-            <Button onClick={handleStartInit}>Start!</Button>
+            <Button onClick={handleStartInit}>Load</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/components/characters/initiative/initiativeTracker.tsx
+++ b/src/components/characters/initiative/initiativeTracker.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
-import { SkipBack, SkipForward, Sword, Swords } from 'lucide-react';
+import { Plus, SkipBack, SkipForward, Sword, Swords, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import ConditionPicker, { CONDITIONS } from './conditionPicker';
 import HpCell from './hpCell';
+import AddCombatantDialog from './addCombatantDialog';
 import InitiativeEndDialog from './initiativeEndDialog';
 import InitiativeSetupDialog from './initiativeSetupDialog';
 import { Actor, sendMessage } from '../../../lib/sync';
@@ -13,22 +16,32 @@ import { useEncounterStore } from '../../../store/encounterStore';
 import StatBlockCard from '../../encounters/statBlockCard';
 
 export default function InitiativeTracker() {
-  const { actors, selectedIndex, round, setActors, setSelectedIndex, setRound, reset } =
-    useCombatStore();
+  const {
+    actors,
+    selectedIndex,
+    round,
+    started,
+    setActors,
+    setSelectedIndex,
+    setRound,
+    setStarted,
+    reset
+  } = useCombatStore();
   const [setupOpen, setSetupOpen] = useState(false);
   const [endOpen, setEndOpen] = useState(false);
+  const [addOpen, setAddOpen] = useState(false);
   const [viewingStatBlockId, setViewingStatBlockId] = useState<string | null>(null);
   const setInitiativeActive = useUiStore((s) => s.setInitiativeActive);
   const statBlocks = useEncounterStore((s) => s.statBlocks);
 
   useEffect(() => {
-    if (actors.length === 0) return;
+    if (!started) return;
     sendMessage({ cmd: 'init_update', payload: { actors, index: selectedIndex, round } });
-  }, [selectedIndex, actors, round]);
+  }, [selectedIndex, actors, round, started]);
 
   useEffect(() => {
-    setInitiativeActive(actors.length > 0);
-  }, [actors.length, setInitiativeActive]);
+    setInitiativeActive(started);
+  }, [started, setInitiativeActive]);
 
   const autoFollow = (nextActors: Actor[], nextIndex: number) => {
     const a = nextActors[nextIndex];
@@ -59,12 +72,19 @@ export default function InitiativeTracker() {
     }
   };
 
-  const startInitiative = (newActors: Actor[]) => {
+  const loadInitiative = (newActors: Actor[]) => {
     setSetupOpen(false);
     setActors(newActors);
     setSelectedIndex(0);
     setRound(1);
-    autoFollow(newActors, 0);
+    setStarted(false);
+  };
+
+  const handleStart = () => {
+    const sorted = [...actors].sort((a, b) => b.init - a.init);
+    setActors(sorted);
+    setStarted(true);
+    autoFollow(sorted, 0);
   };
 
   const handleReset = () => {
@@ -73,6 +93,26 @@ export default function InitiativeTracker() {
     setEndOpen(false);
     setViewingStatBlockId(null);
   };
+
+  const addCombatant = (incoming: Actor[]) => {
+    if (started) {
+      // After combat starts, new combatants drop to the end — don't disrupt the current order
+      setActors([...actors, ...incoming]);
+    } else {
+      const newActors = [...actors, ...incoming].sort((a, b) => b.init - a.init);
+      const currentActor = actors[selectedIndex];
+      const newIndex = currentActor ? newActors.findIndex((a) => a.id === currentActor.id) : 0;
+      setActors(newActors);
+      setSelectedIndex(newIndex);
+    }
+  };
+
+  const updateActorInit = (id: string, init: number) =>
+    setActors(actors.map((a) => (a.id === id ? { ...a, init } : a)));
+
+  const commitInitSort = () => setActors([...actors].sort((a, b) => b.init - a.init));
+
+  const deleteActor = (id: string) => setActors(actors.filter((a) => a.id !== id));
 
   const toggleVisible = (id: string) =>
     setActors(actors.map((a) => (a.id === id ? { ...a, visible: !a.visible } : a)));
@@ -99,8 +139,7 @@ export default function InitiativeTracker() {
       actors.map((a) => {
         if (a.id !== id) return a;
         const hp = Math.max(0, rawHp);
-        // Auto-mark inactive when HP reaches 0
-        return { ...a, hp, active: hp > 0 ? a.active : false };
+        return { ...a, hp, active: hp > 0 };
       })
     );
   };
@@ -119,17 +158,18 @@ export default function InitiativeTracker() {
       <InitiativeSetupDialog
         isOpen={setupOpen}
         handleClose={() => setSetupOpen(false)}
-        onStartInitiative={startInitiative}
+        onStartInitiative={loadInitiative}
       />
       <InitiativeEndDialog
         isOpen={endOpen}
         handleClose={() => setEndOpen(false)}
         handleEndInitiative={handleReset}
       />
+      <AddCombatantDialog isOpen={addOpen} onClose={() => setAddOpen(false)} onAdd={addCombatant} />
       <div className='shrink-0 p-3 space-y-3'>
         {actors.length > 0 ? (
           <>
-            <div className='text-xs text-muted-foreground'>Round {round}</div>
+            {started && <div className='text-xs text-muted-foreground'>Round {round}</div>}
             <div className='space-y-1'>
               <div className='grid grid-cols-[2.5rem_1fr_7.5rem_4rem_4rem_2rem] gap-1 px-1 text-xs text-muted-foreground'>
                 <span>Init</span>
@@ -143,12 +183,27 @@ export default function InitiativeTracker() {
                 <div
                   key={actor.id}
                   className={`px-1 py-0.5 rounded text-sm border-l-2 transition-colors ${
-                    selectedIndex === index
+                    started && selectedIndex === index
                       ? 'bg-primary/10 border-primary'
                       : 'bg-muted/40 border-transparent'
                   }`}>
                   <div className='grid grid-cols-[2.5rem_1fr_7.5rem_4rem_4rem_2rem] gap-1 items-center'>
-                    <span className='tabular-nums text-muted-foreground'>{actor.init}</span>
+                    {started ? (
+                      <span className='tabular-nums text-muted-foreground'>{actor.init}</span>
+                    ) : (
+                      <Input
+                        type='number'
+                        value={actor.init}
+                        onChange={(e) => updateActorInit(actor.id, Number(e.target.value))}
+                        onFocus={(e) => e.target.select()}
+                        onBlur={commitInitSort}
+                        onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.blur()}
+                        className={cn(
+                          'h-6 w-full text-xs px-1 text-center',
+                          actor.init === 0 && 'border-amber-500 bg-amber-500/10 text-amber-400'
+                        )}
+                      />
+                    )}
                     <span
                       className={`flex items-center gap-1.5 ${
                         actor.active ? '' : 'line-through text-muted-foreground'
@@ -158,7 +213,7 @@ export default function InitiativeTracker() {
                           : ''
                       }`}
                       onClick={() => handleNpcNameClick(actor)}>
-                      {selectedIndex === index && (
+                      {started && selectedIndex === index && (
                         <Sword className='h-3 w-3 text-primary shrink-0' />
                       )}
                       {actor.name}
@@ -187,10 +242,18 @@ export default function InitiativeTracker() {
                       />
                     </div>
                     <div className='flex justify-center'>
-                      <ConditionPicker
-                        conditions={actor.conditions}
-                        onToggle={(c) => toggleCondition(actor.id, c)}
-                      />
+                      {started ? (
+                        <ConditionPicker
+                          conditions={actor.conditions}
+                          onToggle={(c) => toggleCondition(actor.id, c)}
+                        />
+                      ) : (
+                        <button
+                          className='flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-destructive hover:bg-muted'
+                          onClick={() => deleteActor(actor.id)}>
+                          <Trash2 className='h-3.5 w-3.5' />
+                        </button>
+                      )}
                     </div>
                   </div>
                   {actor.conditions.length > 0 && (
@@ -219,21 +282,42 @@ export default function InitiativeTracker() {
         )}
 
         <div className='flex items-center gap-2'>
-          <Button variant='outline' size='icon' onClick={prevTurn} disabled={actors.length === 0}>
-            <SkipBack className='h-4 w-4' />
-          </Button>
-          <Button variant='outline' size='icon' onClick={nextTurn} disabled={actors.length === 0}>
-            <SkipForward className='h-4 w-4' />
-          </Button>
-          <div className='flex-1' />
           {actors.length === 0 ? (
-            <Button size='sm' onClick={() => setSetupOpen(true)}>
-              New Combat
-            </Button>
+            <>
+              <div className='flex-1' />
+              <Button size='sm' onClick={() => setSetupOpen(true)}>
+                Load Combat
+              </Button>
+            </>
+          ) : !started ? (
+            <>
+              <Button variant='outline' size='sm' onClick={handleReset}>
+                Discard
+              </Button>
+              <div className='flex-1' />
+              <Button variant='outline' size='icon' onClick={() => setAddOpen(true)}>
+                <Plus className='h-4 w-4' />
+              </Button>
+              <Button size='sm' onClick={handleStart}>
+                Start
+              </Button>
+            </>
           ) : (
-            <Button variant='destructive' size='sm' onClick={() => setEndOpen(true)}>
-              End
-            </Button>
+            <>
+              <Button variant='outline' size='icon' onClick={prevTurn}>
+                <SkipBack className='h-4 w-4' />
+              </Button>
+              <Button variant='outline' size='icon' onClick={nextTurn}>
+                <SkipForward className='h-4 w-4' />
+              </Button>
+              <div className='flex-1' />
+              <Button variant='outline' size='icon' onClick={() => setAddOpen(true)}>
+                <Plus className='h-4 w-4' />
+              </Button>
+              <Button variant='destructive' size='sm' onClick={() => setEndOpen(true)}>
+                End
+              </Button>
+            </>
           )}
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -127,4 +127,12 @@
   html {
     @apply font-sans;
   }
+  input[type='number'] {
+    appearance: textfield;
+  }
+  input[type='number']::-webkit-outer-spin-button,
+  input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -59,6 +59,14 @@ const NPC_NOUNS = [
   'Warden'
 ];
 
+export function rollInitiative(dexMod = 0): number {
+  return Math.floor(Math.random() * 20) + 1 + dexMod;
+}
+
+export function dexModifier(dex: number): number {
+  return Math.floor((dex - 10) / 2);
+}
+
 export function randomNpcName(): string {
   const adj = NPC_ADJECTIVES[Math.floor(Math.random() * NPC_ADJECTIVES.length)];
   const noun = NPC_NOUNS[Math.floor(Math.random() * NPC_NOUNS.length)];

--- a/src/pages/dm-screen.tsx
+++ b/src/pages/dm-screen.tsx
@@ -32,7 +32,7 @@ const DmScreen = () => {
     : 'home';
   const lastSentImage = useUiStore((s) => s.lastSentImage);
   const setLastSentImage = useUiStore((s) => s.setLastSentImage);
-  const initiativeActive = useCombatStore((s) => s.actors.length > 0);
+  const initiativeActive = useCombatStore((s) => s.started);
 
   useEffect(() => {
     document.title = 'DM Screen';

--- a/src/store/__tests__/migrations.test.ts
+++ b/src/store/__tests__/migrations.test.ts
@@ -130,9 +130,18 @@ const v0Notes = { notes: 'Session notes here.' };
 
 const v0Combat = { actors: [], selectedIndex: 0, round: 1 };
 
+const v1Combat = Object.freeze({ actors: [], selectedIndex: 0, round: 1, started: false });
+
 describe('combatStore migrations', () => {
-  it('v0 state is preserved', () => {
-    expect(migrateCombatStore(v0Combat, 0), CONTRACT_BROKEN).toEqual(v0Combat);
+  it('v1 state is preserved', () => {
+    expect(migrateCombatStore(structuredClone(v1Combat), 1), CONTRACT_BROKEN).toEqual(v1Combat);
+  });
+
+  it('v0 → v1: started added as false', () => {
+    const result = migrateCombatStore(structuredClone(v0Combat), 0) as typeof v1Combat;
+    expect(result.started, CONTRACT_BROKEN).toBe(false);
+    expect(result.actors, CONTRACT_BROKEN).toEqual([]);
+    expect(result.round, CONTRACT_BROKEN).toBe(1);
   });
 });
 

--- a/src/store/combatStore.ts
+++ b/src/store/combatStore.ts
@@ -6,15 +6,20 @@ interface CombatStore {
   actors: Actor[];
   selectedIndex: number;
   round: number;
+  started: boolean;
   setActors: (actors: Actor[]) => void;
   setSelectedIndex: (index: number) => void;
   setRound: (round: number) => void;
+  setStarted: (started: boolean) => void;
   reset: () => void;
 }
 
 export const STORE_KEY = 'dm-screen/combat';
 
-export function migrateCombatStore(state: unknown, _version: number): unknown {
+export function migrateCombatStore(state: unknown, version: number): unknown {
+  if (version < 1) {
+    (state as Record<string, unknown>).started = false;
+  }
   return state;
 }
 
@@ -24,14 +29,16 @@ export const useCombatStore = create<CombatStore>()(
       actors: [],
       selectedIndex: 0,
       round: 1,
+      started: false,
       setActors: (actors) => set({ actors }),
       setSelectedIndex: (selectedIndex) => set({ selectedIndex }),
       setRound: (round) => set({ round }),
-      reset: () => set({ actors: [], selectedIndex: 0, round: 1 })
+      setStarted: (started) => set({ started }),
+      reset: () => set({ actors: [], selectedIndex: 0, round: 1, started: false })
     }),
     {
       name: STORE_KEY,
-      version: 0,
+      version: 1,
       migrate: migrateCombatStore
     }
   )


### PR DESCRIPTION
## Summary

Overhauls the initiative tracker with a three-phase combat flow and significant UX improvements to the setup and mid-combat experience.

## What changed

- **`combatStore.ts`** — v0→v1 migration adds `started: boolean` to separate loaded vs running state; new `setStarted` action
- **`initiativeTracker.tsx`** — three-phase button row (Load Combat / [Discard + + + Start] / [← → + End]); loaded state shows editable init inputs with amber highlight for zeros, per-row delete, inline re-sort on blur/Enter; sync to players only fires when `started`; NPC HP→0 marks inactive, HP>0 re-activates; header swords icon only appears when combat is started
- **`initiativeSetupDialog.tsx`** — NPCs auto-roll initiative (1d20 for manual adds, 1d20+DEX mod when loading an encounter template); submit renamed "Load"; encounter apply button renamed "Apply" to avoid ambiguity
- **`addCombatantDialog.tsx`** — new dialog for mid-combat adds; searchable stat block picker (inline dropdown, avoids Radix portal/Dialog focus trap conflict); auto-rolls initiative from DEX mod; mid-combat adds drop to end of order
- **`index.css`** — globally removes number input spinners; `onFocus` select-all on all number inputs in combat forms
- **`utils.ts`** — `rollInitiative(dexMod?)` and `dexModifier(dex)` helpers
- **`dm-screen.tsx`** — `initiativeActive` now derived from `started` instead of `actors.length > 0`
- **`migrations.test.ts`** — v1 combat snapshot + v0→v1 migration test; setup dialog test updated for renamed buttons

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Tested in the browser (dev server)
- [ ] No regressions in related features