### PR TITLE
feat: stage multiple images on the player view with per-image name controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,17 +33,17 @@ The DM and player views communicate via **PartyKit WebSockets** (`src/lib/sync.t
 
 **State layer** (`src/store/`) — Zustand stores with `persist` middleware:
 
-| Store            | localStorage key                    | Backed up by export? | Notes                                                                                                  |
-| ---------------- | ----------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------ |
-| `campaignStore`  | `dm-screen/campaigns`               | ✅                   | Campaigns with UUID ids + active campaign pointer                                                      |
-| `characterStore` | `dm-screen/characters`              | ✅                   | Player characters with UUID ids; `campaignId` for filtering                                            |
-| `imageStore`     | `dm-screen/images`                  | ✅                   | Folders + image URLs; enforces unique URLs per folder                                                  |
-| `notesStore`     | `dm-screen/notes`                   | ✅                   | Single freeform notes string                                                                           |
-| `encounterStore` | `dm-screen/encounters`              | ✅                   | Stat blocks + named encounter templates                                                                |
-| `combatStore`    | `dm-screen/combat`                  | ❌ ephemeral         | Active initiative state; `started` flag separates loaded vs running; survives page refresh, not export |
-| `dmSessionStore` | `dm-screen/dm-session`              | ❌ ephemeral         | `wantLive` flag (persist intent to reconnect after refresh)                                            |
-| `playerStore`    | `dm-screen/player`                  | ❌ per-browser       | Player's display name; set once on the player view                                                     |
-| `uiStore`        | `dm-screen/ui` (lastSentImage only) | ❌ ephemeral         | `lastSentImage` persisted via `partialize`; `initiativeActive` is memory-only                          |
+| Store            | localStorage key            | Backed up by export? | Notes                                                                                                   |
+| ---------------- | --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------- |
+| `campaignStore`  | `dm-screen/campaigns`       | ✅                   | Campaigns with UUID ids + active campaign pointer                                                       |
+| `characterStore` | `dm-screen/characters`      | ✅                   | Player characters with UUID ids; `campaignId` for filtering                                             |
+| `imageStore`     | `dm-screen/images`          | ✅                   | Folders + image URLs; enforces unique URLs per folder                                                   |
+| `notesStore`     | `dm-screen/notes`           | ✅                   | Single freeform notes string                                                                            |
+| `encounterStore` | `dm-screen/encounters`      | ✅                   | Stat blocks + named encounter templates                                                                 |
+| `combatStore`    | `dm-screen/combat`          | ❌ ephemeral         | Active initiative state; `started` flag separates loaded vs running; survives page refresh, not export  |
+| `dmSessionStore` | `dm-screen/dm-session`      | ❌ ephemeral         | `wantLive` flag (persist intent to reconnect after refresh)                                             |
+| `playerStore`    | `dm-screen/player`          | ❌ per-browser       | Player's display name; set once on the player view                                                      |
+| `uiStore`        | `dm-screen/ui` (stage only) | ❌ ephemeral         | `stage` (images shown on the player view) persisted via `partialize`; `initiativeActive` is memory-only |
 
 Each store that participates in export/import exports `STORE_KEY` and a `migrateXxxStore` function. The migration functions are tested in `src/store/__tests__/migrations.test.ts` — when you add a store version bump, add a frozen snapshot and a test there too.
 
@@ -66,7 +66,7 @@ Each store that participates in export/import exports `STORE_KEY` and a `migrate
 
 **Initiative**: Three-phase flow — **Load** → **Start** → **End**. `InitiativeTracker` → open `InitiativeSetupDialog` (seeds players from active campaign, lets DM add NPCs with auto-rolled initiative, optionally apply an encounter template) → "Load" sorts actors into `combatStore` with `started: false`. In loaded state the DM can edit initiatives inline, add/delete actors, and wait for PC rolls (zero-init cells are amber). "Start" re-sorts and sets `started: true`, which begins turn tracking and starts syncing to players. Mid-combat, "+" opens `AddCombatantDialog` (searchable stat-block picker, auto-rolled init); new combatants drop to the end of the order. NPC HP → 0 marks them inactive; HP > 0 re-activates.
 
-**Images**: `ImageSender` (paste a URL, send ad-hoc) or `ImageGrid` (saved folder images) → `onSendImage` → `sendMessage({ cmd: 'image', payload })` → player view renders it full-screen.
+**Images**: The player view mirrors a **stage** — an array of images (`uiStore.stage`), not a single image. `ImageSender` (paste a URL) and `ImageGrid` (saved folder images) **toggle** images on/off the stage via `onToggleImage`; each toggle re-sends the full array with `sendMessage({ cmd: 'stage_update', payload: { images } })` (idempotent — empty array clears). Each image carries an `aspectRatio` (measured on load, backfilled into `imageStore`). The player view's `StageLayout` (`src/components/player/stageLayout.tsx`) lays them out by role inferred from ratio: wide (≥1.4) reads as a location/backdrop, square/tall as an NPC portrait — e.g. one wide backdrop + portraits along the bottom. When initiative is also running, it moves from a floating overlay into a dedicated right-hand rail so it never overlaps the images.
 
 **Export/Import**: Header dropdown → `exportData()` writes the 5 backed-up stores to a dated JSON file; `importData(file)` restores them to localStorage and reloads the page so Zustand's `migrate` pipeline runs on the new data.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Two GitHub Actions secrets are required for the deploy workflow:
 - **More prominent combat indicator** — make the active-combat indicator in the DM header more noticeable.
 - **Show hidden-name status on DM tiles** — surface a "name hidden from players" marker on image thumbnails in the manage/grid views.
 - **Reveal/hide names mid-session** — toggle an image's name visibility live from the stage without editing the image (if low effort).
-- **Player stage: reduce NPC/location obstruction** — tune portrait scale/layout so staged NPC portraits don't cover the location backdrop.
+- ~~**Player stage: reduce NPC/location obstruction** — tune portrait scale/layout so staged NPC portraits don't cover the location backdrop.~~
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ A lightweight DM screen for true tabletop play. Open the DM view on your laptop,
 - Track player characters (AC, Passive Perception, Passive Insight, initiative bonus, sheet link, background)
 - Run initiative: add monsters/NPCs with HP, enter rolls, advance turns, apply conditions, toggle visible/alive
 - Manage encounter templates — pre-build enemy rosters, load them at the table
-- Manage saved images in folders, push any image to the player screen
+- Manage saved images in folders; toggle one or several onto the player screen at once
 - Freeform markdown notes panel
 
 **Player view** — shown on your second monitor:
 
 - Sees the current initiative order (with hidden enemies shown as `? ? ? ? ? ?`)
 - Conditions and round count displayed per actor
-- Displays whatever image the DM sends
+- Displays the images the DM stages — auto-arranged by aspect ratio (wide locations as backdrops, square/tall NPC portraits over them); initiative moves to a side rail when images share the screen
 
 The two views sync via **PartyKit** WebSockets — the DM and players can be on completely different devices and networks. Open the DM view on your laptop, share the player link with anyone at the table, and push images and combat state in real time.
 
@@ -56,7 +56,7 @@ The sync layer (`src/lib/sync.ts`) is a module-level singleton wrapping `partyso
 1. DM creates a campaign in Prep Mode and assigns it a slug (e.g. `my-campaign`)
 2. DM clicks **Go Live** — connects to a PartyKit room keyed on the slug
 3. Players navigate to `/players/my-campaign` on any device, enter their name, and connect
-4. DM sees a live player count with join times; players see initiative and whatever image the DM sends
+4. DM sees a live player count with join times; players see initiative and whatever images the DM has staged
 
 **DM presence:**
 
@@ -64,7 +64,7 @@ The server tracks `dmConnected` and `everHadDm` in room state. Players use this 
 
 **State on reconnect:**
 
-When the DM reconnects, `onConnectionChange` fires and immediately pushes current local combat state and the last-sent image to the server. Players get a `dm_sync` and are up to date without any action from the DM. `lastSentImage` is persisted in `uiStore` so it survives a DM browser refresh.
+When the DM reconnects, `onConnectionChange` fires and immediately pushes current local combat state and the staged images to the server. Players get a `dm_sync` and are up to date without any action from the DM. The `stage` array is persisted in `uiStore` so it survives a DM browser refresh.
 
 **HP privacy:**
 
@@ -88,6 +88,11 @@ Two GitHub Actions secrets are required for the deploy workflow:
 ## Backlog
 
 - ~~**Import confirmation** — Before `importData()` runs, warn the user that all current data will be overwritten.~~ ✅
+- **Clear stage from the navbar** — add a clear-stage control to the top DM navbar (not just the Images tab).
+- **More prominent combat indicator** — make the active-combat indicator in the DM header more noticeable.
+- **Show hidden-name status on DM tiles** — surface a "name hidden from players" marker on image thumbnails in the manage/grid views.
+- **Reveal/hide names mid-session** — toggle an image's name visibility live from the stage without editing the image (if low effort).
+- **Player stage: reduce NPC/location obstruction** — tune portrait scale/layout so staged NPC portraits don't cover the location backdrop.
 
 ## Known Limitations
 

--- a/party/index.ts
+++ b/party/index.ts
@@ -13,11 +13,18 @@ interface Actor {
   statBlockId?: string;
 }
 
+interface StageImage {
+  id: string;
+  url: string;
+  title?: string;
+  aspectRatio?: number;
+}
+
 interface RoomState {
   actors: Omit<Actor, 'hp' | 'maxHp'>[];
   index: number;
   round: number;
-  image: { url: string; title?: string } | null;
+  stage: StageImage[];
   players: { id: string; name: string; connectedAt: number }[];
   dmConnected: boolean;
   everHadDm: boolean;
@@ -32,7 +39,7 @@ export default class DmScreenServer implements Party.Server {
     actors: [],
     index: 0,
     round: 1,
-    image: null,
+    stage: [],
     players: [],
     dmConnected: false,
     everHadDm: false
@@ -69,7 +76,7 @@ export default class DmScreenServer implements Party.Server {
             actors: this.state.actors,
             index: this.state.index,
             round: this.state.round,
-            image: this.state.image
+            images: this.state.stage
           }
         })
       );
@@ -97,19 +104,15 @@ export default class DmScreenServer implements Party.Server {
           this.broadcastToPlayers({ ...msg, payload: { ...msg.payload, actors } });
           break;
         }
-        case 'image':
-          this.state.image = msg.payload;
-          this.broadcastToPlayers(msg);
-          break;
-        case 'clear_image':
-          this.state.image = null;
+        case 'stage_update':
+          this.state.stage = msg.payload.images;
           this.broadcastToPlayers(msg);
           break;
         case 'session_ended':
           this.state.actors = [];
           this.state.index = 0;
           this.state.round = 1;
-          this.state.image = null;
+          this.state.stage = [];
           this.broadcastToPlayers(msg);
           break;
       }
@@ -123,7 +126,7 @@ export default class DmScreenServer implements Party.Server {
             actors: this.state.actors,
             index: this.state.index,
             round: this.state.round,
-            image: this.state.image
+            images: this.state.stage
           }
         })
       );

--- a/src/components/campaigns/campaignEditDialog.tsx
+++ b/src/components/campaigns/campaignEditDialog.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter
@@ -112,6 +113,11 @@ export default function CampaignEditDialog({
       <DialogContent className='max-w-md'>
         <DialogHeader>
           <DialogTitle>{campaign === null ? 'New Campaign' : 'Edit Campaign'}</DialogTitle>
+          <DialogDescription>
+            {campaign === null
+              ? 'Create a campaign to organize characters, encounters, and the player view.'
+              : 'Update this campaign’s details.'}
+          </DialogDescription>
         </DialogHeader>
         {open && <CampaignEditForm campaign={campaign} onClose={onClose} onSave={onSave} />}
       </DialogContent>

--- a/src/components/campaigns/goLiveButton.tsx
+++ b/src/components/campaigns/goLiveButton.tsx
@@ -31,15 +31,15 @@ export default function GoLiveButton() {
   const actors = useCombatStore((s) => s.actors);
   const selectedIndex = useCombatStore((s) => s.selectedIndex);
   const round = useCombatStore((s) => s.round);
-  const lastSentImage = useUiStore((s) => s.lastSentImage);
+  const stage = useUiStore((s) => s.stage);
   const wantLive = useDmSessionStore((s) => s.wantLive);
   const setWantLive = useDmSessionStore((s) => s.setWantLive);
   const [isLive, setIsLive] = useState(false);
   const [players, setPlayers] = useState<{ name: string; connectedAt: number }[]>([]);
 
-  const stateRef = useRef({ actors, selectedIndex, round, lastSentImage });
+  const stateRef = useRef({ actors, selectedIndex, round, stage });
   useEffect(() => {
-    stateRef.current = { actors, selectedIndex, round, lastSentImage };
+    stateRef.current = { actors, selectedIndex, round, stage };
   });
 
   const activeCampaign = campaigns.find((c) => c.id === activeCampaignId);
@@ -48,13 +48,9 @@ export default function GoLiveButton() {
     return onConnectionChange((connected) => {
       setIsLive(connected);
       if (connected) {
-        const { actors, selectedIndex, round, lastSentImage } = stateRef.current;
+        const { actors, selectedIndex, round, stage } = stateRef.current;
         sendMessage({ cmd: 'init_update', payload: { actors, index: selectedIndex, round } });
-        if (lastSentImage) {
-          sendMessage({ cmd: 'image', payload: lastSentImage });
-        } else {
-          sendMessage({ cmd: 'clear_image' });
-        }
+        sendMessage({ cmd: 'stage_update', payload: { images: stage } });
       } else {
         setPlayers([]);
       }

--- a/src/components/characters/characterEditDialog.tsx
+++ b/src/components/characters/characterEditDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter
@@ -198,6 +199,11 @@ export default function CharacterEditDialog({
       <DialogContent className='max-w-md'>
         <DialogHeader>
           <DialogTitle>{character === null ? 'New Character' : 'Edit Character'}</DialogTitle>
+          <DialogDescription>
+            {character === null
+              ? 'Add a player character to the active campaign.'
+              : 'Update this character’s details.'}
+          </DialogDescription>
         </DialogHeader>
         {open && (
           <CharacterEditForm

--- a/src/components/characters/initiative/addCombatantDialog.tsx
+++ b/src/components/characters/initiative/addCombatantDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter
@@ -86,6 +87,9 @@ export default function AddCombatantDialog({ isOpen, onClose, onAdd }: Props) {
       <DialogContent className='max-w-xs'>
         <DialogHeader>
           <DialogTitle>Add Combatant</DialogTitle>
+          <DialogDescription>
+            Add a combatant to the current initiative order with an auto-rolled initiative.
+          </DialogDescription>
         </DialogHeader>
 
         <div className='space-y-3'>

--- a/src/components/characters/initiative/initiativeSetupDialog.tsx
+++ b/src/components/characters/initiative/initiativeSetupDialog.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter
@@ -129,6 +130,9 @@ export default function InitiativeSetupDialog({
         <DialogContent className='max-w-2xl'>
           <DialogHeader>
             <DialogTitle>Set Up Initiative</DialogTitle>
+            <DialogDescription>
+              Add combatants and roll initiative, then load them into the tracker.
+            </DialogDescription>
           </DialogHeader>
 
           <div className='space-y-4 max-h-[60vh] overflow-y-auto'>

--- a/src/components/characters/initiative/initiativeSetupDialog.tsx
+++ b/src/components/characters/initiative/initiativeSetupDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -50,9 +50,13 @@ export default function InitiativeSetupDialog({
   const [actors, setActors] = useState<Actor[]>(() => newPlayerActors(characters));
   const [loadEncounterId, setLoadEncounterId] = useState('');
 
-  useEffect(() => {
+  // Re-seed players each time the dialog opens, without an effect (see
+  // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes).
+  const [wasOpen, setWasOpen] = useState(isOpen);
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen);
     if (isOpen) setActors(newPlayerActors(characters));
-  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
   const { target: deleteTarget, requestDelete, clearDelete } = useConfirmDelete<Actor>();
 
   const encounterTemplates = useEncounterStore((s) => s.templates);

--- a/src/components/encounters/ddbImportDialog.tsx
+++ b/src/components/encounters/ddbImportDialog.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { StatBlock } from '../../store/encounterStore';
 import { parseDdbStatBlock } from '../../lib/ddbParser';
@@ -23,12 +29,12 @@ export default function DdbImportDialog({ isOpen, onClose, onSelect }: Props) {
       <DialogContent className='max-w-md'>
         <DialogHeader>
           <DialogTitle>Import from D&amp;D Beyond</DialogTitle>
-        </DialogHeader>
-        <div className='space-y-3'>
-          <p className='text-sm text-muted-foreground'>
+          <DialogDescription>
             Go to a monster page on D&amp;D Beyond, select all stat block content, copy it, then
             paste below.
-          </p>
+          </DialogDescription>
+        </DialogHeader>
+        <div className='space-y-3'>
           <Textarea
             autoFocus
             placeholder='Paste here…'

--- a/src/components/encounters/open5eSearchDialog.tsx
+++ b/src/components/encounters/open5eSearchDialog.tsx
@@ -1,5 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Loader2 } from 'lucide-react';
@@ -224,6 +230,9 @@ export default function Open5eSearchDialog({ isOpen, onClose, onSelect }: Props)
       <DialogContent className='max-w-3xl sm:max-w-3xl'>
         <DialogHeader>
           <DialogTitle>Search Open5e</DialogTitle>
+          <DialogDescription>
+            Search the Open5e database and import a monster as a stat block.
+          </DialogDescription>
         </DialogHeader>
         <div className='space-y-3'>
           <Input

--- a/src/components/encounters/open5eSearchDialog.tsx
+++ b/src/components/encounters/open5eSearchDialog.tsx
@@ -182,10 +182,8 @@ export default function Open5eSearchDialog({ isOpen, onClose, onSelect }: Props)
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (query.trim().length < 2) {
-      setResults([]);
-      return;
-    }
+    // Stale results stay in state but are gated out of render by `showResults`.
+    if (query.trim().length < 2) return;
     const controller = new AbortController();
     debounceRef.current = setTimeout(async () => {
       setLoading(true);

--- a/src/components/images/add-image-dialog.tsx
+++ b/src/components/images/add-image-dialog.tsx
@@ -1,14 +1,15 @@
 import { ChangeEvent, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import SimpleDialog from '@/components/ui/simple-dialog';
 
 interface AddImageDialogProps {
   open: boolean;
   onClose: () => void;
   targetFolder: string;
-  onSave: (url: string, title: string) => boolean;
-  initialValues?: { url: string; title: string };
+  onSave: (url: string, title: string, hideName: boolean) => boolean;
+  initialValues?: { url: string; title: string; hideName: boolean };
 }
 
 export default function AddImageDialog({
@@ -21,18 +22,20 @@ export default function AddImageDialog({
   const isEdit = !!initialValues;
   const [url, setUrl] = useState(initialValues?.url ?? '');
   const [imageTitle, setImageTitle] = useState(initialValues?.title ?? '');
+  const [hideName, setHideName] = useState(initialValues?.hideName ?? false);
   const [dupeError, setDupeError] = useState(false);
 
   const handleClose = () => {
     setUrl('');
     setImageTitle('');
+    setHideName(false);
     setDupeError(false);
     onClose();
   };
 
   const handleSave = () => {
     if (!url.trim()) return;
-    const added = onSave(url.trim(), imageTitle.trim());
+    const added = onSave(url.trim(), imageTitle.trim(), hideName);
     if (!added) {
       setDupeError(true);
       return;
@@ -61,6 +64,15 @@ export default function AddImageDialog({
             placeholder='Dragon cave map'
           />
         </div>
+        <label className='flex items-center justify-between gap-3 rounded-md border px-3 py-2'>
+          <span className='text-sm'>
+            Hide name from players
+            <span className='block text-xs text-muted-foreground'>
+              You still see the title; players see no caption.
+            </span>
+          </span>
+          <Switch checked={hideName} onCheckedChange={setHideName} />
+        </label>
         <div className='space-y-1'>
           <Label htmlFor='add-img-url'>Image URL</Label>
           <Input

--- a/src/components/images/folder-list.tsx
+++ b/src/components/images/folder-list.tsx
@@ -5,9 +5,10 @@ import {
   AccordionItem,
   AccordionTrigger
 } from '@/components/ui/accordion';
-import { Check, Images, Plus } from 'lucide-react';
+import { Check, EyeOff, Images, Plus } from 'lucide-react';
 import ImageGrid from './imageGrid';
 import ImageThumbnail from './image-thumbnail';
+import NameToggle from './name-toggle';
 import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image, ImageFolder } from '../../store/imageStore';
@@ -17,10 +18,19 @@ interface FolderListProps {
   folders: ImageFolder[];
   search: string;
   stagedIds: Set<string>;
+  nameShownIds: Set<string>;
   onToggleImage: (image: Image) => void;
+  onToggleName: (image: Image) => void;
 }
 
-export default function FolderList({ folders, search, stagedIds, onToggleImage }: FolderListProps) {
+export default function FolderList({
+  folders,
+  search,
+  stagedIds,
+  nameShownIds,
+  onToggleImage,
+  onToggleName
+}: FolderListProps) {
   const [openFolder, setOpenFolder] = useState<string>(folders[0]?.folderName ?? '');
 
   if (folders.length === 0) {
@@ -54,51 +64,62 @@ export default function FolderList({ folders, search, stagedIds, onToggleImage }
         {matches.map(({ img, folderName }) => {
           const staged = stagedIds.has(img.id);
           return (
-            <HoverCard key={img.id} openDelay={300}>
-              <HoverCardTrigger asChild>
-                <button
-                  type='button'
-                  onClick={() => onToggleImage(img)}
-                  className={cn(
-                    'block text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
-                    staged ? 'ring-primary' : 'ring-transparent'
-                  )}>
-                  <ImageThumbnail
-                    image={img}
-                    imgClassName='w-full h-24 object-cover'
-                    action={
-                      <>
-                        <span className='text-xs text-white/50 truncate flex-1 mr-1'>
-                          {folderName}
-                        </span>
-                        <Button
-                          variant='ghost'
-                          size='icon'
-                          className='h-6 w-6 shrink-0 pointer-events-none'
-                          tabIndex={-1}>
-                          {staged ? (
-                            <Check className='h-3.5 w-3.5 text-primary' />
-                          ) : (
-                            <Plus className='h-3.5 w-3.5' />
+            <div key={img.id} className='relative'>
+              <HoverCard openDelay={300}>
+                <HoverCardTrigger asChild>
+                  <button
+                    type='button'
+                    onClick={() => onToggleImage(img)}
+                    className={cn(
+                      'block w-full text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
+                      staged ? 'ring-primary' : 'ring-transparent'
+                    )}>
+                    <ImageThumbnail
+                      image={img}
+                      imgClassName='w-full h-24 object-cover'
+                      action={
+                        <>
+                          <span className='text-xs text-white/50 truncate flex-1 mr-1'>
+                            {folderName}
+                          </span>
+                          {img.hideName && img.title && (
+                            <EyeOff
+                              className='h-3.5 w-3.5 shrink-0 text-amber-400'
+                              aria-label='Name hidden from players by default'
+                            />
                           )}
-                        </Button>
-                      </>
-                    }
+                          <Button
+                            variant='ghost'
+                            size='icon'
+                            className='h-6 w-6 shrink-0 pointer-events-none'
+                            tabIndex={-1}>
+                            {staged ? (
+                              <Check className='h-3.5 w-3.5 text-primary' />
+                            ) : (
+                              <Plus className='h-3.5 w-3.5' />
+                            )}
+                          </Button>
+                        </>
+                      }
+                    />
+                  </button>
+                </HoverCardTrigger>
+                <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+                  <img
+                    src={img.url}
+                    alt={img.title}
+                    className='w-full rounded object-contain max-h-[70vh]'
                   />
-                </button>
-              </HoverCardTrigger>
-              <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
-                <img
-                  src={img.url}
-                  alt={img.title}
-                  className='w-full rounded object-contain max-h-[70vh]'
-                />
-                {img.title && (
-                  <p className='text-xs text-muted-foreground mt-1 truncate'>{img.title}</p>
-                )}
-                <p className='text-xs text-muted-foreground/60 mt-0.5 truncate'>{folderName}</p>
-              </HoverCardContent>
-            </HoverCard>
+                  {img.title && (
+                    <p className='text-xs text-muted-foreground mt-1 truncate'>{img.title}</p>
+                  )}
+                  <p className='text-xs text-muted-foreground/60 mt-0.5 truncate'>{folderName}</p>
+                </HoverCardContent>
+              </HoverCard>
+              {staged && img.title && (
+                <NameToggle shown={nameShownIds.has(img.id)} onClick={() => onToggleName(img)} />
+              )}
+            </div>
           );
         })}
       </div>
@@ -132,7 +153,9 @@ export default function FolderList({ folders, search, stagedIds, onToggleImage }
                 <ImageGrid
                   images={sortedImages}
                   stagedIds={stagedIds}
+                  nameShownIds={nameShownIds}
                   onToggleImage={onToggleImage}
+                  onToggleName={onToggleName}
                 />
               ) : (
                 <p className='text-sm text-muted-foreground py-2'>No images yet.</p>

--- a/src/components/images/folder-list.tsx
+++ b/src/components/images/folder-list.tsx
@@ -5,20 +5,22 @@ import {
   AccordionItem,
   AccordionTrigger
 } from '@/components/ui/accordion';
-import { Images, Send } from 'lucide-react';
+import { Check, Images, Plus } from 'lucide-react';
 import ImageGrid from './imageGrid';
 import ImageThumbnail from './image-thumbnail';
 import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image, ImageFolder } from '../../store/imageStore';
+import { cn } from '../../lib/utils';
 
 interface FolderListProps {
   folders: ImageFolder[];
   search: string;
-  onSendImage: (image: Image) => void;
+  stagedIds: Set<string>;
+  onToggleImage: (image: Image) => void;
 }
 
-export default function FolderList({ folders, search, onSendImage }: FolderListProps) {
+export default function FolderList({ folders, search, stagedIds, onToggleImage }: FolderListProps) {
   const [openFolder, setOpenFolder] = useState<string>(folders[0]?.folderName ?? '');
 
   if (folders.length === 0) {
@@ -49,43 +51,56 @@ export default function FolderList({ folders, search, onSendImage }: FolderListP
 
     return (
       <div className='grid grid-cols-6 gap-2'>
-        {matches.map(({ img, folderName }) => (
-          <HoverCard key={img.id} openDelay={300}>
-            <HoverCardTrigger asChild>
-              <div>
-                <ImageThumbnail
-                  image={img}
-                  imgClassName='w-full h-24 object-cover'
-                  action={
-                    <>
-                      <span className='text-xs text-white/50 truncate flex-1 mr-1'>
-                        {folderName}
-                      </span>
-                      <Button
-                        variant='ghost'
-                        size='icon'
-                        className='h-6 w-6 shrink-0'
-                        onClick={() => onSendImage(img)}>
-                        <Send className='h-3.5 w-3.5' />
-                      </Button>
-                    </>
-                  }
+        {matches.map(({ img, folderName }) => {
+          const staged = stagedIds.has(img.id);
+          return (
+            <HoverCard key={img.id} openDelay={300}>
+              <HoverCardTrigger asChild>
+                <button
+                  type='button'
+                  onClick={() => onToggleImage(img)}
+                  className={cn(
+                    'block text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
+                    staged ? 'ring-primary' : 'ring-transparent'
+                  )}>
+                  <ImageThumbnail
+                    image={img}
+                    imgClassName='w-full h-24 object-cover'
+                    action={
+                      <>
+                        <span className='text-xs text-white/50 truncate flex-1 mr-1'>
+                          {folderName}
+                        </span>
+                        <Button
+                          variant='ghost'
+                          size='icon'
+                          className='h-6 w-6 shrink-0 pointer-events-none'
+                          tabIndex={-1}>
+                          {staged ? (
+                            <Check className='h-3.5 w-3.5 text-primary' />
+                          ) : (
+                            <Plus className='h-3.5 w-3.5' />
+                          )}
+                        </Button>
+                      </>
+                    }
+                  />
+                </button>
+              </HoverCardTrigger>
+              <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+                <img
+                  src={img.url}
+                  alt={img.title}
+                  className='w-full rounded object-contain max-h-[70vh]'
                 />
-              </div>
-            </HoverCardTrigger>
-            <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
-              <img
-                src={img.url}
-                alt={img.title}
-                className='w-full rounded object-contain max-h-[70vh]'
-              />
-              {img.title && (
-                <p className='text-xs text-muted-foreground mt-1 truncate'>{img.title}</p>
-              )}
-              <p className='text-xs text-muted-foreground/60 mt-0.5 truncate'>{folderName}</p>
-            </HoverCardContent>
-          </HoverCard>
-        ))}
+                {img.title && (
+                  <p className='text-xs text-muted-foreground mt-1 truncate'>{img.title}</p>
+                )}
+                <p className='text-xs text-muted-foreground/60 mt-0.5 truncate'>{folderName}</p>
+              </HoverCardContent>
+            </HoverCard>
+          );
+        })}
       </div>
     );
   }
@@ -114,7 +129,11 @@ export default function FolderList({ folders, search, onSendImage }: FolderListP
             </AccordionTrigger>
             <AccordionContent className='px-3 pb-3'>
               {sortedImages.length > 0 ? (
-                <ImageGrid images={sortedImages} onSendImage={onSendImage} />
+                <ImageGrid
+                  images={sortedImages}
+                  stagedIds={stagedIds}
+                  onToggleImage={onToggleImage}
+                />
               ) : (
                 <p className='text-sm text-muted-foreground py-2'>No images yet.</p>
               )}

--- a/src/components/images/image-thumbnail.tsx
+++ b/src/components/images/image-thumbnail.tsx
@@ -1,4 +1,4 @@
-import { Image } from '../../store/imageStore';
+import { Image, useImageStore } from '../../store/imageStore';
 
 interface ImageThumbnailProps {
   image: Image;
@@ -7,11 +7,24 @@ interface ImageThumbnailProps {
 }
 
 export default function ImageThumbnail({ image, action, imgClassName }: ImageThumbnailProps) {
+  const setImageAspectRatio = useImageStore((s) => s.setImageAspectRatio);
+
+  // Backfill aspect ratio the first time an image loads, so the player view
+  // can lay it out by role (wide location vs square portrait) without measuring.
+  const handleLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    if (image.aspectRatio != null) return;
+    const { naturalWidth, naturalHeight } = e.currentTarget;
+    if (naturalWidth && naturalHeight) {
+      setImageAspectRatio(image.id, naturalWidth / naturalHeight);
+    }
+  };
+
   return (
     <div className='relative bg-card rounded overflow-hidden group'>
       <img
         src={image.url}
         alt={image.title}
+        onLoad={handleLoad}
         className={
           imgClassName ??
           'w-full h-48 object-cover transition-transform duration-200 group-hover:scale-105'

--- a/src/components/images/imageGrid.tsx
+++ b/src/components/images/imageGrid.tsx
@@ -17,7 +17,7 @@ export default function ImageGrid({ images, stagedIds, onToggleImage }: ImageGri
       {images.map((image) => {
         const staged = stagedIds.has(image.id);
         return (
-          <HoverCard key={image.id} openDelay={300}>
+          <HoverCard key={image.id} openDelay={300} closeDelay={0}>
             <HoverCardTrigger asChild>
               <button
                 type='button'
@@ -45,7 +45,10 @@ export default function ImageGrid({ images, stagedIds, onToggleImage }: ImageGri
                 />
               </button>
             </HoverCardTrigger>
-            <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+            <HoverCardContent
+              side='right'
+              sideOffset={8}
+              className='pointer-events-none w-[min(480px,55vw)] p-2'>
               <img
                 src={image.url}
                 alt={image.title}

--- a/src/components/images/imageGrid.tsx
+++ b/src/components/images/imageGrid.tsx
@@ -1,48 +1,63 @@
-import { Send } from 'lucide-react';
+import { Check, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image } from '../../store/imageStore';
 import ImageThumbnail from './image-thumbnail';
+import { cn } from '../../lib/utils';
 
 interface ImageGridProps {
   images: Image[];
-  onSendImage: (image: Image) => void;
+  stagedIds: Set<string>;
+  onToggleImage: (image: Image) => void;
 }
 
-export default function ImageGrid({ images, onSendImage }: ImageGridProps) {
+export default function ImageGrid({ images, stagedIds, onToggleImage }: ImageGridProps) {
   return (
     <div className='grid grid-cols-6 gap-2'>
-      {images.map((image) => (
-        <HoverCard key={image.id} openDelay={300}>
-          <HoverCardTrigger asChild>
-            <div>
-              <ImageThumbnail
-                image={image}
-                imgClassName='w-full h-24 object-cover'
-                action={
-                  <Button
-                    variant='ghost'
-                    size='icon'
-                    className='h-6 w-6 ml-auto'
-                    onClick={() => onSendImage(image)}>
-                    <Send className='h-3.5 w-3.5' />
-                  </Button>
-                }
+      {images.map((image) => {
+        const staged = stagedIds.has(image.id);
+        return (
+          <HoverCard key={image.id} openDelay={300}>
+            <HoverCardTrigger asChild>
+              <button
+                type='button'
+                onClick={() => onToggleImage(image)}
+                className={cn(
+                  'block text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
+                  staged ? 'ring-primary' : 'ring-transparent'
+                )}>
+                <ImageThumbnail
+                  image={image}
+                  imgClassName='w-full h-24 object-cover'
+                  action={
+                    <Button
+                      variant='ghost'
+                      size='icon'
+                      className='h-6 w-6 ml-auto pointer-events-none'
+                      tabIndex={-1}>
+                      {staged ? (
+                        <Check className='h-3.5 w-3.5 text-primary' />
+                      ) : (
+                        <Plus className='h-3.5 w-3.5' />
+                      )}
+                    </Button>
+                  }
+                />
+              </button>
+            </HoverCardTrigger>
+            <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
+              <img
+                src={image.url}
+                alt={image.title}
+                className='w-full rounded object-contain max-h-[70vh]'
               />
-            </div>
-          </HoverCardTrigger>
-          <HoverCardContent side='right' sideOffset={8} className='w-[min(480px,55vw)] p-2'>
-            <img
-              src={image.url}
-              alt={image.title}
-              className='w-full rounded object-contain max-h-[70vh]'
-            />
-            {image.title && (
-              <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
-            )}
-          </HoverCardContent>
-        </HoverCard>
-      ))}
+              {image.title && (
+                <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
+              )}
+            </HoverCardContent>
+          </HoverCard>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/images/imageGrid.tsx
+++ b/src/components/images/imageGrid.tsx
@@ -1,64 +1,86 @@
-import { Check, Plus } from 'lucide-react';
+import { Check, EyeOff, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Image } from '../../store/imageStore';
 import ImageThumbnail from './image-thumbnail';
+import NameToggle from './name-toggle';
 import { cn } from '../../lib/utils';
 
 interface ImageGridProps {
   images: Image[];
   stagedIds: Set<string>;
+  nameShownIds: Set<string>;
   onToggleImage: (image: Image) => void;
+  onToggleName: (image: Image) => void;
 }
 
-export default function ImageGrid({ images, stagedIds, onToggleImage }: ImageGridProps) {
+export default function ImageGrid({
+  images,
+  stagedIds,
+  nameShownIds,
+  onToggleImage,
+  onToggleName
+}: ImageGridProps) {
   return (
     <div className='grid grid-cols-6 gap-2'>
       {images.map((image) => {
         const staged = stagedIds.has(image.id);
         return (
-          <HoverCard key={image.id} openDelay={300} closeDelay={0}>
-            <HoverCardTrigger asChild>
-              <button
-                type='button'
-                onClick={() => onToggleImage(image)}
-                className={cn(
-                  'block text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
-                  staged ? 'ring-primary' : 'ring-transparent'
-                )}>
-                <ImageThumbnail
-                  image={image}
-                  imgClassName='w-full h-24 object-cover'
-                  action={
-                    <Button
-                      variant='ghost'
-                      size='icon'
-                      className='h-6 w-6 ml-auto pointer-events-none'
-                      tabIndex={-1}>
-                      {staged ? (
-                        <Check className='h-3.5 w-3.5 text-primary' />
-                      ) : (
-                        <Plus className='h-3.5 w-3.5' />
-                      )}
-                    </Button>
-                  }
+          <div key={image.id} className='relative'>
+            <HoverCard openDelay={300} closeDelay={0}>
+              <HoverCardTrigger asChild>
+                <button
+                  type='button'
+                  onClick={() => onToggleImage(image)}
+                  className={cn(
+                    'block w-full text-left rounded ring-2 ring-offset-1 ring-offset-background transition-shadow',
+                    staged ? 'ring-primary' : 'ring-transparent'
+                  )}>
+                  <ImageThumbnail
+                    image={image}
+                    imgClassName='w-full h-24 object-cover'
+                    action={
+                      <div className='flex items-center gap-1 ml-auto'>
+                        {image.hideName && image.title && (
+                          <EyeOff
+                            className='h-3.5 w-3.5 text-amber-400'
+                            aria-label='Name hidden from players by default'
+                          />
+                        )}
+                        <Button
+                          variant='ghost'
+                          size='icon'
+                          className='h-6 w-6 pointer-events-none'
+                          tabIndex={-1}>
+                          {staged ? (
+                            <Check className='h-3.5 w-3.5 text-primary' />
+                          ) : (
+                            <Plus className='h-3.5 w-3.5' />
+                          )}
+                        </Button>
+                      </div>
+                    }
+                  />
+                </button>
+              </HoverCardTrigger>
+              <HoverCardContent
+                side='right'
+                sideOffset={8}
+                className='pointer-events-none w-[min(480px,55vw)] p-2'>
+                <img
+                  src={image.url}
+                  alt={image.title}
+                  className='w-full rounded object-contain max-h-[70vh]'
                 />
-              </button>
-            </HoverCardTrigger>
-            <HoverCardContent
-              side='right'
-              sideOffset={8}
-              className='pointer-events-none w-[min(480px,55vw)] p-2'>
-              <img
-                src={image.url}
-                alt={image.title}
-                className='w-full rounded object-contain max-h-[70vh]'
-              />
-              {image.title && (
-                <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
-              )}
-            </HoverCardContent>
-          </HoverCard>
+                {image.title && (
+                  <p className='text-xs text-muted-foreground mt-1 truncate'>{image.title}</p>
+                )}
+              </HoverCardContent>
+            </HoverCard>
+            {staged && image.title && (
+              <NameToggle shown={nameShownIds.has(image.id)} onClick={() => onToggleName(image)} />
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/components/images/imageSender.tsx
+++ b/src/components/images/imageSender.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Loader2, Send } from 'lucide-react';
+import { Loader2, Plus } from 'lucide-react';
 import { Image } from '../../store/imageStore';
 
 interface ImageSenderProps {
@@ -25,7 +25,9 @@ export default function ImageSender({ onSendImage }: ImageSenderProps) {
     setError(null);
     const img = new window.Image();
     img.onload = () => {
-      onSendImage({ id: crypto.randomUUID(), url, displayOrder: 0 });
+      const aspectRatio =
+        img.naturalWidth && img.naturalHeight ? img.naturalWidth / img.naturalHeight : undefined;
+      onSendImage({ id: crypto.randomUUID(), url, displayOrder: 0, aspectRatio });
       setImageUrl('');
       setLoading(false);
     };
@@ -51,7 +53,7 @@ export default function ImageSender({ onSendImage }: ImageSenderProps) {
           className='flex-1'
         />
         <Button onClick={handleSend} disabled={!imageUrl.trim() || loading} size='sm'>
-          {loading ? <Loader2 className='h-4 w-4 animate-spin' /> : <Send className='h-4 w-4' />}
+          {loading ? <Loader2 className='h-4 w-4 animate-spin' /> : <Plus className='h-4 w-4' />}
         </Button>
       </div>
       {error && <p className='text-xs text-destructive'>{error}</p>}

--- a/src/components/images/images.tsx
+++ b/src/components/images/images.tsx
@@ -1,32 +1,69 @@
 import { useState } from 'react';
 import FolderList from './folder-list';
 import ImageSender from './imageSender';
-import { sendMessage } from '../../lib/sync';
+import { sendMessage, StageImage } from '../../lib/sync';
 import { useImageStore, Image } from '../../store/imageStore';
 import { useUiStore } from '../../store/uiStore';
 import SectionHeader from '@/components/ui/section-header';
 import { Input } from '@/components/ui/input';
-import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Layers, X } from 'lucide-react';
+
+function toStageImage(item: Image): StageImage {
+  return {
+    id: item.id,
+    url: item.url,
+    // Hidden-name images stay nameless to players (the DM still sees the title locally).
+    title: item.hideName ? undefined : item.title,
+    aspectRatio: item.aspectRatio
+  };
+}
 
 export default function Images() {
   const folders = useImageStore((s) => s.folders);
-  const setLastSentImage = useUiStore((s) => s.setLastSentImage);
+  const stage = useUiStore((s) => s.stage);
+  const setStage = useUiStore((s) => s.setStage);
   const [search, setSearch] = useState('');
 
-  const sendImageToPlayerView = (item: Image) => {
-    sendMessage({ cmd: 'image', payload: item });
-    setLastSentImage(item);
+  const stagedIds = new Set(stage.map((i) => i.id));
+
+  const pushStage = (next: StageImage[]) => {
+    setStage(next);
+    sendMessage({ cmd: 'stage_update', payload: { images: next } });
   };
+
+  const toggleImage = (item: Image) => {
+    const next = stagedIds.has(item.id)
+      ? stage.filter((i) => i.id !== item.id)
+      : [...stage, toStageImage(item)];
+    pushStage(next);
+  };
+
+  const clearStage = () => pushStage([]);
 
   return (
     <div className='space-y-4'>
       <section>
         <SectionHeader className='mb-2'>Quick Send</SectionHeader>
-        <ImageSender onSendImage={sendImageToPlayerView} />
+        <ImageSender onSendImage={toggleImage} />
       </section>
 
       <section>
-        <SectionHeader className='mb-2'>Saved Images</SectionHeader>
+        <div className='flex items-center justify-between mb-2'>
+          <SectionHeader className='mb-0'>Saved Images</SectionHeader>
+          {stage.length > 0 && (
+            <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+              <span className='flex items-center gap-1'>
+                <Layers className='h-3.5 w-3.5' />
+                On stage ({stage.length})
+              </span>
+              <Button variant='outline' size='sm' className='h-6 px-2' onClick={clearStage}>
+                <X className='h-3 w-3 mr-1' />
+                Clear
+              </Button>
+            </div>
+          )}
+        </div>
         <div className='relative mb-3'>
           <Input
             placeholder='Search images…'
@@ -42,7 +79,12 @@ export default function Images() {
             </button>
           )}
         </div>
-        <FolderList folders={folders} search={search} onSendImage={sendImageToPlayerView} />
+        <FolderList
+          folders={folders}
+          search={search}
+          stagedIds={stagedIds}
+          onToggleImage={toggleImage}
+        />
       </section>
     </div>
   );

--- a/src/components/images/images.tsx
+++ b/src/components/images/images.tsx
@@ -26,6 +26,8 @@ export default function Images() {
   const [search, setSearch] = useState('');
 
   const stagedIds = new Set(stage.map((i) => i.id));
+  // Staged images whose name is currently sent to players (title present).
+  const nameShownIds = new Set(stage.filter((i) => i.title).map((i) => i.id));
 
   const pushStage = (next: StageImage[]) => {
     setStage(next);
@@ -36,6 +38,16 @@ export default function Images() {
     const next = stagedIds.has(item.id)
       ? stage.filter((i) => i.id !== item.id)
       : [...stage, toStageImage(item)];
+    pushStage(next);
+  };
+
+  // Flip a staged image's name visibility for players without touching its saved
+  // hideName setting — just adds/removes the title on the live stage entry.
+  const toggleName = (item: Image) => {
+    if (!item.title) return;
+    const next = stage.map((i) =>
+      i.id === item.id ? { ...i, title: i.title ? undefined : item.title } : i
+    );
     pushStage(next);
   };
 
@@ -83,7 +95,9 @@ export default function Images() {
           folders={folders}
           search={search}
           stagedIds={stagedIds}
+          nameShownIds={nameShownIds}
           onToggleImage={toggleImage}
+          onToggleName={toggleName}
         />
       </section>
     </div>

--- a/src/components/images/manage-images-panel.tsx
+++ b/src/components/images/manage-images-panel.tsx
@@ -430,7 +430,7 @@ export default function ManageImagesPanel() {
         open={subDialog === 'addImage'}
         onClose={closeSub}
         targetFolder={targetFolder}
-        onSave={(url, title) => addImage(targetFolder, url, title || undefined)}
+        onSave={(url, title, hideName) => addImage(targetFolder, url, title || undefined, hideName)}
       />
 
       <AddImageDialog
@@ -439,14 +439,20 @@ export default function ManageImagesPanel() {
         onClose={closeSub}
         targetFolder={targetFolder}
         initialValues={
-          editTarget ? { url: editTarget.url, title: editTarget.title ?? '' } : undefined
+          editTarget
+            ? {
+                url: editTarget.url,
+                title: editTarget.title ?? '',
+                hideName: !!editTarget.hideName
+              }
+            : undefined
         }
-        onSave={(url, title) => {
+        onSave={(url, title, hideName) => {
           if (!editTarget) return false;
           const folder = folders.find((f) => f.folderName === targetFolder);
           const isDupe = folder?.images.some((img) => img.url === url && img.id !== editTarget.id);
           if (isDupe) return false;
-          updateImage(targetFolder, editTarget.id, { url, title: title || undefined });
+          updateImage(targetFolder, editTarget.id, { url, title: title || undefined, hideName });
           return true;
         }}
       />

--- a/src/components/images/name-toggle.tsx
+++ b/src/components/images/name-toggle.tsx
@@ -1,0 +1,26 @@
+import { Eye, EyeOff } from 'lucide-react';
+
+interface NameToggleProps {
+  /** Whether the name is currently shown to players. */
+  shown: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Overlay button shown on a staged image tile. Flips whether the image's name is
+ * sent to players right now — independent of the saved "hide name" setting.
+ */
+export default function NameToggle({ shown, onClick }: NameToggleProps) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      title={
+        shown ? 'Name shown to players — click to hide' : 'Name hidden from players — click to show'
+      }
+      aria-label={shown ? 'Hide name from players' : 'Show name to players'}
+      className='absolute top-1 right-1 z-10 inline-flex h-6 w-6 items-center justify-center rounded bg-black/70 text-white hover:bg-black/90'>
+      {shown ? <Eye className='h-3.5 w-3.5' /> : <EyeOff className='h-3.5 w-3.5' />}
+    </button>
+  );
+}

--- a/src/components/player/stageLayout.tsx
+++ b/src/components/player/stageLayout.tsx
@@ -1,0 +1,105 @@
+import { StageImage } from '../../lib/sync';
+
+/** Images at or above this width/height ratio read as "wide" (location/backdrop). */
+const WIDE_RATIO = 1.4;
+
+function isWide(img: StageImage): boolean {
+  return (img.aspectRatio ?? 1) >= WIDE_RATIO;
+}
+
+function Portrait({
+  img,
+  className = '',
+  maxH = 'max-h-full'
+}: {
+  img: StageImage;
+  className?: string;
+  /** Tailwind max-height class bounding the image (keeps it off the focal point). */
+  maxH?: string;
+}) {
+  return (
+    <figure className={`relative flex items-end justify-center min-h-0 ${className}`}>
+      <img
+        src={img.url}
+        alt={img.title}
+        className={`min-h-0 ${maxH} max-w-full object-contain rounded-lg shadow-2xl shadow-black/60`}
+      />
+      {/* Name overlays the image bottom — no reserved band, so portraits line up. */}
+      {img.title && (
+        <figcaption className='absolute inset-x-0 bottom-2 flex justify-center px-2'>
+          <span className='px-3 py-0.5 rounded-full bg-black/70 text-white/95 text-lg font-medium truncate max-w-[90%]'>
+            {img.title}
+          </span>
+        </figcaption>
+      )}
+    </figure>
+  );
+}
+
+/**
+ * Lays images out by role inferred from aspect ratio:
+ *  - one image            → full-screen contain
+ *  - one wide + portraits → wide as backdrop, portraits as a bottom row
+ *  - all portraits        → centered row
+ *  - anything else        → contain grid
+ */
+export default function StageLayout({ images }: { images: StageImage[] }) {
+  if (images.length === 0) return null;
+
+  if (images.length === 1) {
+    const img = images[0];
+    return <img src={img.url} alt={img.title} className='w-full h-full object-contain' />;
+  }
+
+  const wides = images.filter(isWide);
+  const portraits = images.filter((i) => !isWide(i));
+
+  // Location + characters: backdrop scales to fit (whole image visible);
+  // portraits are capped to the lower ~30vh and anchored to the bottom, so the
+  // top ~70% of the scene (the focal point) is never covered. A scrim grounds them.
+  if (wides.length === 1 && portraits.length >= 1) {
+    const backdrop = wides[0];
+    return (
+      <div className='relative w-full h-full'>
+        <img
+          src={backdrop.url}
+          alt={backdrop.title}
+          className='absolute inset-0 w-full h-full object-contain object-top'
+        />
+        <div className='absolute inset-x-0 bottom-0 flex items-end justify-center gap-8 px-8 pb-4'>
+          {portraits.map((img) => (
+            <Portrait key={img.id} img={img} maxH='max-h-[30vh]' className='max-w-[32%]' />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // All portraits: even row across the middle.
+  if (wides.length === 0) {
+    return (
+      <div className='flex items-center justify-center gap-6 w-full h-full p-6'>
+        {portraits.map((img) => (
+          <Portrait key={img.id} img={img} className='flex-1' />
+        ))}
+      </div>
+    );
+  }
+
+  // Fallback: contain grid.
+  const cols = images.length <= 4 ? 2 : 3;
+  return (
+    <div
+      className='grid gap-3 w-full h-full p-3'
+      style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
+      {images.map((img) => (
+        <img
+          key={img.id}
+          src={img.url}
+          alt={img.title}
+          className='w-full h-full min-h-0 object-contain'
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -21,12 +21,13 @@ function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.C
   return <DialogPrimitive.Close data-slot='dialog-close' {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentProps<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => {
   return (
     <DialogPrimitive.Overlay
+      ref={ref}
       data-slot='dialog-overlay'
       className={cn(
         'fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
@@ -35,7 +36,8 @@ function DialogOverlay({
       {...props}
     />
   );
-}
+});
+DialogOverlay.displayName = 'DialogOverlay';
 
 function DialogContent({
   className,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,18 +2,22 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
-  return (
-    <input
-      type={type}
-      data-slot='input'
-      className={cn(
-        'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
-        className
-      )}
-      {...props}
-    />
-  );
-}
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        data-slot='input'
+        className={cn(
+          'h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
 
 export { Input };

--- a/src/lib/exportImport.ts
+++ b/src/lib/exportImport.ts
@@ -2,7 +2,7 @@
 //   combatStore     — active combat resets naturally between sessions
 //   dmSessionStore  — wantLive flag is ephemeral connection intent
 //   playerStore     — player name is per-browser, not per-campaign
-//   uiStore         — lastSentImage is ephemeral display state
+//   uiStore         — stage (player display state) is ephemeral
 import { STORE_KEY as CAMPAIGNS_KEY } from '../store/campaignStore';
 import { STORE_KEY as CHARACTERS_KEY } from '../store/characterStore';
 import { STORE_KEY as IMAGES_KEY } from '../store/imageStore';

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -13,9 +13,16 @@ export interface Actor {
   statBlockId?: string;
 }
 
+export interface StageImage {
+  id: string;
+  url: string;
+  title?: string;
+  /** width / height; used by the player view to lay images out by role. */
+  aspectRatio?: number;
+}
+
 export type SyncMessage =
-  | { cmd: 'image'; payload: { url: string; title?: string } }
-  | { cmd: 'clear_image' }
+  | { cmd: 'stage_update'; payload: { images: StageImage[] } }
   | { cmd: 'init_update'; payload: { actors: Actor[]; index: number; round: number } }
   | { cmd: 'player_ready' }
   | {
@@ -24,7 +31,7 @@ export type SyncMessage =
         actors: Actor[];
         index: number;
         round: number;
-        image: { url: string; title?: string } | null;
+        images: StageImage[];
       };
     }
   | { cmd: 'players_update'; payload: { name: string; connectedAt: number }[] }

--- a/src/pages/dm-screen.tsx
+++ b/src/pages/dm-screen.tsx
@@ -30,17 +30,17 @@ const DmScreen = () => {
   const activeTab: DmTab = (VALID_TABS as readonly string[]).includes(searchParams.get('tab') ?? '')
     ? (searchParams.get('tab') as DmTab)
     : 'home';
-  const lastSentImage = useUiStore((s) => s.lastSentImage);
-  const setLastSentImage = useUiStore((s) => s.setLastSentImage);
+  const stage = useUiStore((s) => s.stage);
+  const setStage = useUiStore((s) => s.setStage);
   const initiativeActive = useCombatStore((s) => s.started);
 
   useEffect(() => {
     document.title = 'DM Screen';
   }, []);
 
-  const handleClearImage = () => {
-    setLastSentImage(null);
-    sendMessage({ cmd: 'clear_image' });
+  const handleClearStage = () => {
+    setStage([]);
+    sendMessage({ cmd: 'stage_update', payload: { images: [] } });
   };
 
   return (
@@ -51,24 +51,33 @@ const DmScreen = () => {
 
         <div className='flex-1' />
 
-        {/* Player view indicator */}
+        {/* Player view indicator — thumbnails of what's on the player stage */}
         <div className='flex items-center gap-1.5'>
-          {lastSentImage ? (
+          {stage.length > 0 ? (
             <div className='relative group/img'>
-              <img
-                src={lastSentImage.url}
-                alt={lastSentImage.title}
-                className='h-8 w-8 rounded object-cover border border-border'
-                title={lastSentImage.title ?? lastSentImage.url}
-              />
+              <div className='flex items-center'>
+                {stage.slice(0, 3).map((img, i) => (
+                  <img
+                    key={img.id}
+                    src={img.url}
+                    alt={img.title}
+                    className='h-8 w-8 rounded object-cover border border-border bg-card'
+                    style={{ marginLeft: i === 0 ? 0 : -10, zIndex: stage.length - i }}
+                    title={img.title ?? img.url}
+                  />
+                ))}
+                {stage.length > 3 && (
+                  <span className='ml-1 text-xs text-muted-foreground'>+{stage.length - 3}</span>
+                )}
+              </div>
               {initiativeActive && (
                 <span className='absolute -top-1 -right-1 flex h-3 w-3 items-center justify-center rounded-full bg-amber-500'>
                   <Swords className='h-2 w-2 text-black' />
                 </span>
               )}
               <button
-                onClick={handleClearImage}
-                title='Clear player image'
+                onClick={handleClearStage}
+                title='Clear player stage'
                 className='absolute inset-0 flex items-center justify-center rounded bg-black/60 opacity-0 group-hover/img:opacity-100 transition-opacity'>
                 <X className='h-4 w-4 text-white' />
               </button>

--- a/src/pages/player-view.tsx
+++ b/src/pages/player-view.tsx
@@ -5,7 +5,16 @@ import { Maximize2, Minimize2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import InitiativePlayerView from '../components/characters/initiative/initiativePlayerView';
-import { Actor, checkRoom, connect, disconnect, onMessage, sendMessage } from '../lib/sync';
+import StageLayout from '../components/player/stageLayout';
+import {
+  Actor,
+  StageImage,
+  checkRoom,
+  connect,
+  disconnect,
+  onMessage,
+  sendMessage
+} from '../lib/sync';
 import DebugPanel from '@/components/ui/debug-panel';
 import { usePlayerStore } from '../store/playerStore';
 
@@ -36,7 +45,7 @@ export default function PlayerView() {
   const [roomStatus, setRoomStatus] = useState<'checking' | 'active' | 'inactive'>(() =>
     slug ? 'checking' : 'inactive'
   );
-  const [imageSource, setImageSource] = useState<{ url: string; title?: string } | null>(null);
+  const [stage, setStage] = useState<StageImage[]>([]);
   const [actors, setActors] = useState<Actor[]>([]);
   const [index, setIndex] = useState(0);
   const [round, setRound] = useState(1);
@@ -44,16 +53,18 @@ export default function PlayerView() {
   const [dmStatus, setDmStatus] = useState<'waiting' | 'online' | 'offline' | 'ended'>('waiting');
 
   const showInit = actors.length > 0;
-  const centeredMode = showInit && !imageSource;
+  const showImages = stage.length > 0;
+  const centeredMode = showInit && !showImages;
+  const showRail = showInit && showImages;
 
   const centeredContentRef = useRef<HTMLDivElement>(null);
-  const cornerContentRef = useRef<HTMLDivElement>(null);
+  const railContentRef = useRef<HTMLDivElement>(null);
 
   // Scale initiative down to fit viewport when there are many actors.
   // transform: scale() doesn't affect layout metrics, so offsetHeight always
   // returns the natural height regardless of the current scale — no feedback loop.
-  const centeredScale = useScaleToFit(centeredContentRef, imageSource);
-  const cornerScale = useScaleToFit(cornerContentRef, imageSource);
+  const centeredScale = useScaleToFit(centeredContentRef, stage);
+  const railScale = useScaleToFit(railContentRef, stage);
 
   useEffect(() => {
     document.title = 'Player View';
@@ -74,11 +85,8 @@ export default function PlayerView() {
   useEffect(() => {
     const unsub = onMessage((msg) => {
       switch (msg.cmd) {
-        case 'image':
-          setImageSource(msg.payload);
-          break;
-        case 'clear_image':
-          setImageSource(null);
+        case 'stage_update':
+          setStage(msg.payload.images);
           break;
         case 'init_update':
           setActors(msg.payload.actors);
@@ -86,7 +94,7 @@ export default function PlayerView() {
           setRound(msg.payload.round);
           break;
         case 'dm_sync':
-          setImageSource(msg.payload.image);
+          setStage(msg.payload.images);
           setActors(msg.payload.actors);
           setIndex(msg.payload.index);
           setRound(msg.payload.round);
@@ -98,7 +106,7 @@ export default function PlayerView() {
           setDmStatus((prev) => (prev === 'ended' ? 'ended' : 'offline'));
           break;
         case 'session_ended':
-          setImageSource(null);
+          setStage([]);
           setActors([]);
           setIndex(0);
           setRound(1);
@@ -167,38 +175,20 @@ export default function PlayerView() {
   }
 
   return (
-    <div className='group relative w-screen h-screen overflow-hidden bg-black'>
-      {imageSource ? (
-        <img
-          src={imageSource.url}
-          alt={imageSource.title}
-          className='w-full h-full object-contain'
-        />
-      ) : !centeredMode ? (
-        <BeholderScreen
-          message={dmStatus === 'waiting' ? 'Waiting for DM…' : undefined}
-          pulse={dmStatus === 'waiting'}
-          className='w-full h-full select-none'
-        />
-      ) : null}
+    <div className='group relative w-screen h-screen overflow-hidden bg-black flex'>
+      {/* Main stage area */}
+      <div className='relative flex-1 min-w-0 h-full'>
+        {showImages ? (
+          <StageLayout images={stage} />
+        ) : !centeredMode ? (
+          <BeholderScreen
+            message={dmStatus === 'waiting' ? 'Waiting for DM…' : undefined}
+            pulse={dmStatus === 'waiting'}
+            className='w-full h-full select-none'
+          />
+        ) : null}
 
-      {/* Initiative overlay — corner when image is showing, centered+large when not */}
-      {imageSource ? (
-        <div
-          className={`absolute top-4 right-4 transition-all duration-300 ${
-            showInit ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-2 pointer-events-none'
-          }`}>
-          <div
-            ref={cornerContentRef}
-            style={{ transform: `scale(${cornerScale})`, transformOrigin: 'top right' }}
-            className='bg-black/60 backdrop-blur-sm border border-white/10 rounded-lg px-3 py-2 min-w-32'>
-            <p className='text-xs font-semibold text-white/50 uppercase tracking-wider mb-1.5'>
-              Initiative
-            </p>
-            <InitiativePlayerView actors={actors} turnNumber={index} round={round} />
-          </div>
-        </div>
-      ) : (
+        {/* Centered initiative when nothing is on the stage */}
         <div
           className={`absolute inset-0 flex items-center justify-center transition-all duration-300 ${
             centeredMode ? 'opacity-100' : 'opacity-0 pointer-events-none'
@@ -210,6 +200,21 @@ export default function PlayerView() {
             <InitiativePlayerView actors={actors} turnNumber={index} round={round} large />
           </div>
         </div>
+      </div>
+
+      {/* Initiative rail — dedicated column whenever images share the screen */}
+      {showRail && (
+        <aside className='shrink-0 w-[22vw] max-w-sm min-w-48 h-full bg-black/80 border-l border-white/10 flex items-start justify-center p-4 overflow-hidden'>
+          <div
+            ref={railContentRef}
+            style={{ transform: `scale(${railScale})`, transformOrigin: 'top center' }}
+            className='w-full'>
+            <p className='text-xs font-semibold text-white/50 uppercase tracking-wider mb-2'>
+              Initiative
+            </p>
+            <InitiativePlayerView actors={actors} turnNumber={index} round={round} />
+          </div>
+        </aside>
       )}
 
       {/* DM offline overlay */}

--- a/src/store/imageStore.ts
+++ b/src/store/imageStore.ts
@@ -6,6 +6,10 @@ export interface Image {
   url: string;
   title?: string;
   displayOrder: number;
+  /** width / height; measured lazily when the thumbnail first loads. */
+  aspectRatio?: number;
+  /** When true the title is the DM's reference only — never shown to players. */
+  hideName?: boolean;
 }
 
 export interface ImageFolder {
@@ -19,9 +23,14 @@ interface ImageStore {
   createFolder: (name?: string) => void;
   renameFolder: (oldName: string, newName: string) => void;
   deleteFolder: (folderName: string) => void;
-  addImage: (folderName: string, url: string, title?: string) => boolean;
+  addImage: (folderName: string, url: string, title?: string, hideName?: boolean) => boolean;
   deleteImage: (folderName: string, image: Image) => void;
-  updateImage: (folderName: string, imageId: string, updates: Pick<Image, 'url' | 'title'>) => void;
+  updateImage: (
+    folderName: string,
+    imageId: string,
+    updates: Pick<Image, 'url' | 'title' | 'hideName'>
+  ) => void;
+  setImageAspectRatio: (imageId: string, aspectRatio: number) => void;
   moveImage: (fromFolder: string, toFolder: string, imageId: string) => void;
   reorderImages: (folderName: string, fromIndex: number, toIndex: number) => void;
   reorderFolders: (fromIndex: number, toIndex: number) => void;
@@ -116,7 +125,7 @@ export const useImageStore = create<ImageStore>()(
         set({ folders: remaining.map((f, i) => ({ ...f, displayOrder: i })) });
       },
 
-      addImage: (folderName, url, title) => {
+      addImage: (folderName, url, title, hideName) => {
         if (!url) return false;
         const folder = get().folders.find((f) => f.folderName === folderName);
         if (folder?.images.some((i) => i.url === url)) return false;
@@ -127,7 +136,7 @@ export const useImageStore = create<ImageStore>()(
                   ...f,
                   images: [
                     ...f.images,
-                    { id: crypto.randomUUID(), url, title, displayOrder: f.images.length }
+                    { id: crypto.randomUUID(), url, title, hideName, displayOrder: f.images.length }
                   ]
                 }
               : f
@@ -156,6 +165,19 @@ export const useImageStore = create<ImageStore>()(
                   images: f.images.map((img) => (img.id === imageId ? { ...img, ...updates } : img))
                 }
           )
+        });
+      },
+
+      setImageAspectRatio: (imageId, aspectRatio) => {
+        if (!Number.isFinite(aspectRatio) || aspectRatio <= 0) return;
+        set({
+          folders: get().folders.map((f) => {
+            if (!f.images.some((i) => i.id === imageId && i.aspectRatio == null)) return f;
+            return {
+              ...f,
+              images: f.images.map((img) => (img.id === imageId ? { ...img, aspectRatio } : img))
+            };
+          })
         });
       },
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -1,26 +1,28 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { StageImage } from '../lib/sync';
 
 export const STORE_KEY = 'dm-screen/ui';
 
 interface UiState {
-  lastSentImage: { url: string; title?: string } | null;
+  /** Images currently shown on the player view. */
+  stage: StageImage[];
   initiativeActive: boolean;
-  setLastSentImage: (img: { url: string; title?: string } | null) => void;
+  setStage: (stage: StageImage[]) => void;
   setInitiativeActive: (active: boolean) => void;
 }
 
 export const useUiStore = create<UiState>()(
   persist(
     (set) => ({
-      lastSentImage: null,
+      stage: [],
       initiativeActive: false,
-      setLastSentImage: (img) => set({ lastSentImage: img }),
+      setStage: (stage) => set({ stage }),
       setInitiativeActive: (active) => set({ initiativeActive: active })
     }),
     {
       name: STORE_KEY,
-      partialize: (state) => ({ lastSentImage: state.lastSentImage })
+      partialize: (state) => ({ stage: state.stage })
     }
   )
 );


### PR DESCRIPTION
## Summary

Lets the DM stage multiple images on the player view at once, with per-image name-visibility controls, plus a couple of UX/quality fixes.

## What changed

- **Player stage: multiple images** — the player view mirrors an array of staged images (`uiStore.stage`) instead of a single image; `StageLayout` lays them out by aspect-ratio role (wide backdrop + portraits)
- **Per-image name visibility** — new `name-toggle` control to hide/show an image's name from players, surfaced in the grid/manage views
- **Image hover preview fix** — preview now dismisses when the cursor leaves the tile
- **React warning cleanup** — `forwardRef` on `Input` and `DialogOverlay` (refs work on React 18), and added `DialogDescription` to dialogs that were missing one (fixes radix a11y warnings); `npm run all-checks` now runs clean

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Tested in the browser (dev server)
- [ ] No regressions in related features
